### PR TITLE
Reverse guard for serial allowed

### DIFF
--- a/src/install-button.ts
+++ b/src/install-button.ts
@@ -84,9 +84,9 @@ export class InstallButton extends HTMLElement {
 
     if (!InstallButton.isSupported || !InstallButton.isAllowed) {
       this.toggleAttribute("install-unsupported", true);
-      this.renderRoot.innerHTML = !InstallButton.isSupported
-        ? "<slot name='unsupported'>Your browser does not support installing things on ESP devices. Use Google Chrome or Microsoft Edge.</slot>"
-        : "<slot name='not-allowed'>You can only install ESP devices on HTTPS websites or on the localhost.</slot>";
+      this.renderRoot.innerHTML = !InstallButton.isAllowed
+        ? "<slot name='not-allowed'>You can only install ESP devices on HTTPS websites or on the localhost.</slot>"
+        : "<slot name='unsupported'>Your browser does not support installing things on ESP devices. Use Google Chrome or Microsoft Edge.</slot>";
       return;
     }
 


### PR DESCRIPTION
Warn first if web serial would not be allowed because the context is not secure before checking if web serial is possible.

If web serial is not allowed, it will also be detected as not supported.