### PR TITLE
Also fetch manifest property again

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -18,7 +18,7 @@ export const connect = async (button: InstallButton) => {
 
   const el = document.createElement("ewt-install-dialog");
   el.port = port;
-  el.manifestPath = button.getAttribute("manifest")!;
+  el.manifestPath = button.manifest || button.getAttribute("manifest")!;
   el.addEventListener(
     "closed",
     () => {


### PR DESCRIPTION
Add support back for specifying the `manifest` as a property agian. This got accidentally dropped. Fixes #91 