### PR TITLE
Add support for Home Assistant domain in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Manifest definition:
 {
   "name": "ESPHome",
   "version": "2021.10.3",
+  "home_assistant_domain": "esphome",
   "builds": [
     {
       "chipFamily": "ESP32",

--- a/index.html
+++ b/index.html
@@ -266,6 +266,7 @@
 {
   "name": "ESPHome",
   "version": "2021.11.0",
+  "home_assistant_domain": "esphome",
   "builds": [
     {
       "chipFamily": "ESP32",
@@ -290,6 +291,11 @@
         Each part consists of a path to the file and an offset on the flash
         where it should be installed. Part paths are resolved relative to the
         path of the manifest, but can also be URLs to other hosts.
+      </p>
+      <p>
+        If your firmware is supported by Home Assistant, you can add the
+        optional key <code>home_assistant_domain</code>. If present, ESP Web
+        Tools will link the user to add this device to Home Assistant.
       </p>
       <h3 id="improv">Wi-Fi provisioning</h3>
       <p>

--- a/src/const.ts
+++ b/src/const.ts
@@ -15,6 +15,7 @@ export interface Build {
 export interface Manifest {
   name: string;
   version: string;
+  home_assistant_domain?: string;
   builds: Build[];
 }
 

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -175,7 +175,7 @@ class EwtInstallDialog extends LitElement {
                   class="has-button"
                   target="_blank"
                 >
-                  <ewt-button label="Go to Device"></ewt-button>
+                  <ewt-button label="Visit Device"></ewt-button>
                 </a>
               </div>
             `}
@@ -273,7 +273,7 @@ class EwtInstallDialog extends LitElement {
                       this._state = "DASHBOARD";
                     }}
                   >
-                    <ewt-button label="Go to Device"></ewt-button>
+                    <ewt-button label="Visit Device"></ewt-button>
                   </a>
                 </div>
                 ${!this._manifest.home_assistant_domain

--- a/static/firmware_build/manifest.json
+++ b/static/firmware_build/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "ESPHome",
   "version": "2021.11.0-dev",
+  "home_assistant_domain": "esphome",
   "builds": [
     {
       "chipFamily": "ESP32",


### PR DESCRIPTION
This adds support to specify the domain of the integration in the manifest that supports the firmware that is being installed (optional key `home_assistant_domain`). When available, besides offering to visit the device, it will also offer to add it to Home Assistant.

Installing a new device once connected:
![image](https://user-images.githubusercontent.com/1444314/141218207-0fca58d2-1231-414e-b0e1-2bbc72543dd4.png)


Provisioned device:
![image](https://user-images.githubusercontent.com/1444314/141218159-07c7b1d5-67c2-4ba4-90bf-bc0f38f2ab0d.png)

