### PR TITLE
Allow skipping erasing on new installations

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,10 @@
       <p>
         By default a new installation will erase the entire flash. If you want
         to skip this step, set the optional key
-        <code>new_install_skip_erase</code> to <code>true</code>.
+        <code>new_install_skip_erase</code> to <code>true</code>. ESP Web Tools
+        considers it a new installation if it is unable to detect the current
+        firmware of the device (via Improv Serial) or if the detected firmware
+        does not match the name specififed in the manifest.
       </p>
       <h3 id="improv">Wi-Fi provisioning</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
   "name": "ESPHome",
   "version": "2021.11.0",
   "home_assistant_domain": "esphome",
+  "new_install_skip_erase": false,
   "builds": [
     {
       "chipFamily": "ESP32",
@@ -296,6 +297,11 @@
         If your firmware is supported by Home Assistant, you can add the
         optional key <code>home_assistant_domain</code>. If present, ESP Web
         Tools will link the user to add this device to Home Assistant.
+      </p>
+      <p>
+        By default a new installation will erase the entire flash. If you want
+        to skip this step, set the optional key
+        <code>new_install_skip_erase</code> to <code>true</code>.
       </p>
       <h3 id="improv">Wi-Fi provisioning</h3>
       <p>

--- a/src/const.ts
+++ b/src/const.ts
@@ -16,6 +16,7 @@ export interface Manifest {
   name: string;
   version: string;
   home_assistant_domain?: string;
+  new_install_skip_erase?: boolean;
   builds: Build[];
 }
 

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -580,7 +580,7 @@ class EwtInstallDialog extends LitElement {
         // When it can't detect improv (ie because install failed)
         // We shouldn't reset settings but instead show the error
         if (this._state !== "INSTALL") {
-          this._startInstall(true);
+          this._startInstall(!this._manifest.new_install_skip_erase);
         }
       }
     }

--- a/static/firmware_build/manifest.json
+++ b/static/firmware_build/manifest.json
@@ -2,6 +2,7 @@
   "name": "ESPHome",
   "version": "2021.11.0-dev",
   "home_assistant_domain": "esphome",
+  "new_install_skip_erase": true,
   "builds": [
     {
       "chipFamily": "ESP32",


### PR DESCRIPTION
Introduce new `new_install_skip_erase` option to manifests. Set to `true` to skip erasing all flash when doing a fresh install.

Fixes #100