### PR TITLE
Bump improv-serial-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@material/mwc-linear-progress": "^0.25.1",
         "@material/mwc-textfield": "^0.25.3",
         "esp-web-flasher": "^4.0.0",
-        "improv-wifi-serial-sdk": "^1.0.0",
+        "improv-wifi-serial-sdk": "^1.0.1",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"
       },
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-1.0.0.tgz",
-      "integrity": "sha512-R3NM7Ry9DjTyT5B6iIIZjW5LMia64PwLEJnue5lfYlmqHyJuNMxkWrGomqG7AxQLLCul7CPN1qs52nkJglqYsg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-1.0.1.tgz",
+      "integrity": "sha512-3CCSo98VI0vgJZ+2oWgC9bfqypXOrd0NlNGRK6WmKcaw1lXbHsnDgHOLwA5idz9QwWJSuT67o2eMKssAsEPjfw==",
       "dependencies": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",
@@ -2870,9 +2870,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-1.0.0.tgz",
-      "integrity": "sha512-R3NM7Ry9DjTyT5B6iIIZjW5LMia64PwLEJnue5lfYlmqHyJuNMxkWrGomqG7AxQLLCul7CPN1qs52nkJglqYsg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-1.0.1.tgz",
+      "integrity": "sha512-3CCSo98VI0vgJZ+2oWgC9bfqypXOrd0NlNGRK6WmKcaw1lXbHsnDgHOLwA5idz9QwWJSuT67o2eMKssAsEPjfw==",
       "requires": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@material/mwc-linear-progress": "^0.25.1",
     "@material/mwc-textfield": "^0.25.3",
     "esp-web-flasher": "^4.0.0",
-    "improv-wifi-serial-sdk": "^1.0.0",
+    "improv-wifi-serial-sdk": "^1.0.1",
     "lit": "^2.0.0",
     "tslib": "^2.3.1"
   }


### PR DESCRIPTION
Fixes checksum calculations

Release notes: https://github.com/improv-wifi/sdk-serial-js/releases/tag/1.0.1