### PR TITLE
Remove min width from button

### DIFF
--- a/src/components/ewt-button.ts
+++ b/src/components/ewt-button.ts
@@ -1,3 +1,4 @@
+import { css } from "lit";
 import { ButtonBase } from "@material/mwc-button/mwc-button-base";
 import { styles } from "@material/mwc-button/styles.css";
 
@@ -8,7 +9,14 @@ declare global {
 }
 
 export class EwtButton extends ButtonBase {
-  static override styles = [styles];
+  static override styles = [
+    styles,
+    css`
+      .mdc-button {
+        min-width: initial;
+      }
+    `,
+  ];
 }
 
 customElements.define("ewt-button", EwtButton);


### PR DESCRIPTION
Override the `min-width` on `<mdc-button>` and change it from `64px` to `initial`. It was causing buttons with short texts to be unaligned with the other buttons.

Before:

![CleanShot 2021-11-10 at 20 37 27](https://user-images.githubusercontent.com/1444314/141238017-bfb27c9b-ec34-4c32-90c0-32f948090c04.png)

After:
![CleanShot 2021-11-10 at 20 36 58](https://user-images.githubusercontent.com/1444314/141237957-40f8568d-ffb7-4baf-b7c5-3bb8b5bda18b.png)

