### PR TITLE
Do not silently ignore errors not caused by user closing picker

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -5,8 +5,11 @@ export const connect = async (button: InstallButton) => {
   let port: SerialPort | undefined;
   try {
     port = await navigator.serial.requestPort();
-  } catch (err) {
-    console.error("User cancelled request", err);
+  } catch (err: any) {
+    if ((err as DOMException).name === "NotFoundError") {
+      return;
+    }
+    alert(`Error: ${err.message}`);
     return;
   }
 


### PR DESCRIPTION
`await navigator.serial.requestPort()` will raise not just when the user clicks "cancel", on Widnows it can also raise when the serial port is already in use.

Fixes #113