### PR TITLE
Wait longer for Improv to respond after erase + install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@material/mwc-linear-progress": "^0.25.1",
         "@material/mwc-textfield": "^0.25.3",
         "esp-web-flasher": "^4.0.0",
-        "improv-wifi-serial-sdk": "^2.0.0",
+        "improv-wifi-serial-sdk": "^2.1.0",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"
       },
@@ -1109,9 +1109,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.0.0.tgz",
-      "integrity": "sha512-VHKTm6O3aENOCtEwZZqItJ/dKf0nWJv41iamAUjcKCbQC1PrmZU/91PaWDKQip7WvRlxdKf2PLMKRpnFSeeJYA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.1.0.tgz",
+      "integrity": "sha512-Y+dJGd5MPayWJM810Ni1hrSIunP/htTZgjF39NDVQ/ntWZAvNct3i4oR4jTo1BEb7TDgcHoiLfH5Do6oY4oD1Q==",
       "dependencies": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",
@@ -2870,9 +2870,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.0.0.tgz",
-      "integrity": "sha512-VHKTm6O3aENOCtEwZZqItJ/dKf0nWJv41iamAUjcKCbQC1PrmZU/91PaWDKQip7WvRlxdKf2PLMKRpnFSeeJYA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.1.0.tgz",
+      "integrity": "sha512-Y+dJGd5MPayWJM810Ni1hrSIunP/htTZgjF39NDVQ/ntWZAvNct3i4oR4jTo1BEb7TDgcHoiLfH5Do6oY4oD1Q==",
       "requires": {
         "@material/mwc-button": "^0.25.3",
         "@material/mwc-circular-progress": "^0.25.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@material/mwc-linear-progress": "^0.25.1",
     "@material/mwc-textfield": "^0.25.3",
     "esp-web-flasher": "^4.0.0",
-    "improv-wifi-serial-sdk": "^2.0.0",
+    "improv-wifi-serial-sdk": "^2.1.0",
     "lit": "^2.0.0",
     "tslib": "^2.3.1"
   }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -488,21 +488,17 @@ class EwtInstallDialog extends LitElement {
       (this._installState.state === FlashStateType.FINISHED &&
         this._client === undefined)
     ) {
-      // We represent 3 states:
-      // 1. We're writing the firmware under 4%, show spinner
-      // 2. We're writing the firmware over 4%, show progress bar
-      // 3. We're done writing and detecting improv, show spinner
       let percentage: number | undefined;
       let undeterminateLabel: string | undefined;
-      if (this._installState.state === FlashStateType.WRITING) {
-        // Show as undeterminate under 4% or else we don't show any pixels
-        if (this._installState.details.percentage < 4) {
-          undeterminateLabel = "Installing";
-        } else {
-          percentage = this._installState.details.percentage;
-        }
-      } else {
+      if (this._installState.state === FlashStateType.FINISHED) {
+        // We're done writing and detecting improv, show spinner
         undeterminateLabel = "Wrapping up";
+      } else if (this._installState.details.percentage < 4) {
+        // We're writing the firmware under 4%, show spinner or else we don't show any pixels
+        undeterminateLabel = "Installing";
+      } else {
+        // We're writing the firmware over 4%, show progress bar
+        percentage = this._installState.details.percentage;
       }
       content = this._renderProgress(
         html`

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -481,12 +481,32 @@ class EwtInstallDialog extends LitElement {
     } else if (this._installState.state === FlashStateType.ERASING) {
       content = this._renderProgress("Erasing");
       hideActions = true;
-    } else if (this._installState.state === FlashStateType.WRITING) {
+    } else if (
+      this._installState.state === FlashStateType.WRITING ||
+      // When we're finished, keep showing this screen with 100% written
+      // until Improv is initialized / not detected.
+      (this._installState.state === FlashStateType.FINISHED &&
+        this._client === undefined)
+    ) {
+      // We represent 3 states:
+      // 1. We're writing the firmware under 4%, show spinner
+      // 2. We're writing the firmware over 4%, show progress bar
+      // 3. We're done writing and detecting improv, show spinner
+      let percentage: number | undefined;
+      let undeterminateLabel: string | undefined;
+      if (this._installState.state === FlashStateType.WRITING) {
+        // Show as undeterminate under 4% or else we don't show any pixels
+        if (this._installState.details.percentage < 4) {
+          undeterminateLabel = "Installing";
+        } else {
+          percentage = this._installState.details.percentage;
+        }
+      } else {
+        undeterminateLabel = "Wrapping up";
+      }
       content = this._renderProgress(
         html`
-          ${this._installState.details.percentage > 3
-            ? ""
-            : html`Installing<br />`}
+          ${undeterminateLabel ? html`${undeterminateLabel}<br />` : ""}
           <br />
           This will take
           ${this._installState.chipFamily === "ESP8266"
@@ -494,10 +514,7 @@ class EwtInstallDialog extends LitElement {
             : "2 minutes"}.<br />
           Keep this page visible to prevent slow down
         `,
-        // Show as undeterminate under 3% or else we don't show any pixels
-        this._installState.details.percentage > 3
-          ? this._installState.details.percentage
-          : undefined
+        percentage
       );
       hideActions = true;
     } else if (this._installState.state === FlashStateType.FINISHED) {
@@ -508,7 +525,6 @@ class EwtInstallDialog extends LitElement {
         <ewt-button
           slot="primaryAction"
           label="Next"
-          .disabled=${this._client === undefined}
           @click=${() => {
             this._state =
               supportsImprov && this._installErase ? "PROVISION" : "DASHBOARD";
@@ -613,7 +629,7 @@ class EwtInstallDialog extends LitElement {
     );
   }
 
-  private async _initialize() {
+  private async _initialize(justErased = false) {
     if (this.port.readable === null || this.port.writable === null) {
       this._state = "ERROR";
       this._error =
@@ -628,7 +644,10 @@ class EwtInstallDialog extends LitElement {
     });
     client.addEventListener("error-changed", () => this.requestUpdate());
     try {
-      this._info = await client.initialize();
+      // If a device was just erased, the new firmware might need some time to
+      // format the rest of the flash.
+      const timeout = justErased ? 10000 : 1000;
+      this._info = await client.initialize(timeout);
       this._client = client;
       client.addEventListener("disconnect", this._handleDisconnect);
     } catch (err: any) {
@@ -672,7 +691,7 @@ class EwtInstallDialog extends LitElement {
 
         if (state.state === FlashStateType.FINISHED) {
           sleep(100)
-            .then(() => this._initialize())
+            .then(() => this._initialize(this._installErase))
             .then(() => this.requestUpdate());
         }
       },


### PR DESCRIPTION
A firmware might take longer to boot when doing erase + install. For WLED we see times up to 6.5 seconds. This PR will allow Improv detection to take up to 10 seconds instead of the 1s default when flash was erased.

This PR also changes the screen when writing is done and we're trying to detect Improv. Previously we would show the "Installation complete" dialog and the button would enable when Improv was booted. This is not a good experience with a 10s wait, so instead we will now stay on the "Installing" screen and show "Wrapping up" while detecting Improv.

https://user-images.githubusercontent.com/1444314/141927851-2bfee325-706a-4b5b-a26c-ce158a56cdab.mp4


 