### PR TITLE
Change default button label to "CONNECT"

### DIFF
--- a/src/install-button.ts
+++ b/src/install-button.ts
@@ -104,7 +104,7 @@ export class InstallButton extends HTMLElement {
 
     slot.name = "activate";
     const button = document.createElement("button");
-    button.innerText = "INSTALL";
+    button.innerText = "CONNECT";
     slot.append(button);
     if (
       "adoptedStyleSheets" in Document.prototype &&


### PR DESCRIPTION
Pressing the ESP Web Tools button no longer starts the installation but offers users multiple options. To avoid user confusion the default label has been updated to say "CONNECT" instead of "INSTALL".

Before:
![image](https://user-images.githubusercontent.com/1444314/143624780-967e685f-b0da-418d-9166-8d15dbd3d7b3.png)


After:
![image](https://user-images.githubusercontent.com/1444314/143624759-bee0d52d-5f9e-4e16-bce3-e9c9dda24a7b.png)
