### PR TITLE
Allow configuring improv timeout

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,11 +362,21 @@
       </p>
       <p>
         By default a new installation will erase all data before installation.
-        If you want to leave this choice to the user, set the optional key
+        If you want to leave this choice to the user, set the optional manifest
+        key
         <code>new_install_prompt_erase</code> to <code>true</code>. ESP Web
         Tools offers users a new installation if it is unable to detect the
         current firmware of the device (via Improv Serial) or if the detected
         firmware does not match the name specififed in the manifest.
+      </p>
+      <p>
+        When a firmware is first installed on a device, it might need to do some
+        time consuming tasks like initializing the file system. By default ESP
+        Web Tools will wait 10 seconds to receive an Improv Serial response to
+        indicate that the boot is completed. You can increase this timeout by
+        setting the optional manifest key
+        <code>new_install_improv_wait_time</code> to the number of seconds to
+        wait. Set to <code>0</code> to disable Improv Serial detection.
       </p>
       <h2 id="improv">Configuring Wi-Fi</h2>
       <p>

--- a/src/const.ts
+++ b/src/const.ts
@@ -19,6 +19,8 @@ export interface Manifest {
   /** @deprecated use `new_install_prompt_erase` instead */
   new_install_skip_erase?: boolean;
   new_install_prompt_erase?: boolean;
+  /* Time to wait to detect Improv Wi-Fi. Set to 0 to disable. */
+  new_install_improv_wait_time?: number;
   builds: Build[];
 }
 


### PR DESCRIPTION
Add support for a new `new_install_improv_wait_time` that allow you to specify the time ESP Web Tools should wait for an Improv Serial response after installing the firmware (default is 10 seconds). Set to 0 to disable waiting for Improv. 

@amandel can you verify that this build would solve your problems? 

Fixes #135