### PR TITLE
Change from OK_ICON to ERROR_ICON when flash fails

### DIFF
--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -554,7 +554,7 @@ class EwtInstallDialog extends LitElement {
     } else if (this._installState.state === FlashStateType.ERROR) {
       content = html`
         <ewt-page-message
-          .icon=${OK_ICON}
+          .icon=${ERROR_ICON}
           .label=${this._installState.message}
         ></ewt-page-message>
         <ewt-button


### PR DESCRIPTION
This changes from displaying the OK_ICON to displaying the ERROR_ICON when FlashStateType is ERROR.

This should fix #161 