### PR TITLE
Bump ESP Web Flasher to 5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Manifest definition:
       ]
     },
     {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        { "path": "bootloader_dout_40m.bin", "offset": 4096 },
+        { "path": "partitions.bin", "offset": 32768 },
+        { "path": "boot_app0.bin", "offset": 57344 },
+        { "path": "esp32-s3.bin", "offset": 65536 }
+      ]
+    },
+    {
       "chipFamily": "ESP8266",
       "parts": [
         { "path": "esp8266.bin", "offset": 0 }

--- a/index.html
+++ b/index.html
@@ -337,9 +337,9 @@
         Manifests describe the firmware that you want to offer the user to
         install. It allows specifying different builds for the different types
         of ESP devices. Current supported chip families are
-        <code>ESP8266</code>, <code>ESP32</code>, <code>ESP32-C3</code> and
-        <code>ESP32-S2</code>. The correct build will be automatically selected
-        based on the type of the connected ESP device.
+        <code>ESP8266</code>, <code>ESP32</code>, <code>ESP32-C3</code>,
+        <code>ESP32-S2</code> and <code>ESP32-S3</code>. The correct build will
+        be automatically selected based on the type of the connected ESP device.
       </p>
       <pre>
 {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@material/mwc-formfield": "^0.25.3",
     "@material/mwc-icon-button": "^0.25.3",
     "@material/mwc-textfield": "^0.25.3",
-    "esp-web-flasher": "^5.0.0",
+    "esp-web-flasher": "^5.1.0",
     "improv-wifi-serial-sdk": "^2.1.0",
     "lit": "^2.0.0",
     "tslib": "^2.3.1"

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,7 +5,7 @@ export interface Logger {
 }
 
 export interface Build {
-  chipFamily: "ESP32" | "ESP8266" | "ESP32-S2" | "ESP32-C3";
+  chipFamily: "ESP32" | "ESP8266" | "ESP32-S2" | "ESP32-S3" | "ESP32-C3";
   parts: {
     path: string;
     offset: number;


### PR DESCRIPTION
Adds support for ESP32-S3.

https://github.com/NabuCasa/esp-web-flasher/releases/tag/5.1.0

CC @Jason2866 