### PR TITLE
Improv: handle no SSID list support

### DIFF
--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -397,6 +397,8 @@ class EwtInstallDialog extends LitElement {
           break;
 
         case ImprovSerialErrorState.NO_ERROR:
+        // Happens when list SSIDs not supported.
+        case ImprovSerialErrorState.UNKNOWN_RPC_COMMAND:
           break;
 
         default:


### PR DESCRIPTION
Fixes showing "error 2" when the firmware didn't support listing SSIDs in Improv.

![image](https://user-images.githubusercontent.com/1444314/159736247-8b698a8a-9b50-4bc6-a980-356c7f9c0f94.png)
