### PR TITLE
Don't base font-size on HTML page

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,5 +1,9 @@
 import { css } from "lit";
 
+// We set font-size to 16px and all the mdc typography styles
+// because it defaults to rem, which means that the font-size
+// of the host website would influence the ESP Web Tools dialog.
+
 export const dialogStyles = css`
   :host {
     --mdc-theme-primary: var(--improv-primary-color, #03a9f4);
@@ -9,6 +13,13 @@ export const dialogStyles = css`
     --mdc-theme-text-primary-on-background: var(--improv-text-color);
     --mdc-dialog-content-ink-color: var(--improv-text-color);
     text-align: left;
+    font-size: 16px;
+    --mdc-typography-headline6-font-size: 1.25em;
+    --mdc-typography-headline6-line-height: 2em;
+    --mdc-typography-body1-font-size: 1em;
+    --mdc-typography-body1-line-height: 1.5em;
+    --mdc-typography-button-font-size: 0.875em;
+    --mdc-typography-button-line-height: 2.25em;
   }
 
   a {


### PR DESCRIPTION
By default the MWC components will base their font-size and line-height on `rem`. This means that the hosting website can mess with the look of ESP Web Tools which caused issues with Tasmota. So we now set the CSS variables to base it on `em` and set the font-size to 16px, which is what we designed the dialog to align to.