### PR TITLE
Allow specifying checkFirmware override

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,6 +403,28 @@
         is visible in the ESP Web Tools menu when connected to a device running
         your firmware (as detected via Improv).
       </p>
+      <p>
+        ESP Web Tools allows you to provide your own check if the device is
+        running the same firmware as specified in the manifest. This check can
+        be setting the <code>overrides</code> property on
+        <code>&lt;esp-web-install-button&gt;</code>. The value is an object
+        containing a
+        <code>checkSameFirmwareVersion(manifest, improvInfo)</code> function.
+        The <code>manifest</code> parameter is your manifest and
+        <code>improvInfo</code> is the information returned from Improv:
+        <code>{ name, firmware, version, chipFamily }</code>. This check is only
+        called if the device firmware was detected via Improv.
+      </p>
+      <pre>
+const button = document.querySelector('esp-web-install-button');
+button.overrides = {
+  checkSameFirmwareVersion(manifest, improvInfo) {
+    const manifestFirmware = manifest.name.toLowerCase();
+    const deviceFirmware = improvInfo.firmware.toLowerCase();
+    return manifestFirmware.includes(deviceFirmware);
+  }
+};</pre
+      >
 
       <h3 id="customize">Customizing the look and feel</h3>
       <p>

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -30,6 +30,7 @@ export const connect = async (button: InstallButton) => {
   const el = document.createElement("ewt-install-dialog");
   el.port = port;
   el.manifestPath = button.manifest || button.getAttribute("manifest")!;
+  el.overrides = button.overrides;
   el.addEventListener(
     "closed",
     () => {

--- a/src/install-button.ts
+++ b/src/install-button.ts
@@ -1,4 +1,5 @@
-import { FlashState } from "./const";
+import type { FlashState } from "./const";
+import type { EwtInstallDialog } from "./install-dialog";
 
 export class InstallButton extends HTMLElement {
   public static isSupported = "serial" in navigator;
@@ -70,6 +71,8 @@ export class InstallButton extends HTMLElement {
   public state?: FlashState;
 
   public renderRoot?: ShadowRoot;
+
+  public overrides: EwtInstallDialog["overrides"];
 
   public static preload() {
     import("./connect");

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -30,12 +30,19 @@ import { dialogStyles } from "./styles";
 const ERROR_ICON = "⚠️";
 const OK_ICON = "🎉";
 
-class EwtInstallDialog extends LitElement {
+export class EwtInstallDialog extends LitElement {
   public port!: SerialPort;
 
   public manifestPath!: string;
 
   public logger: Logger = console;
+
+  public overrides?: {
+    checkSameFirmwareVersion?: (
+      manifest: Manifest,
+      deviceImprov: ImprovSerial["info"]
+    ) => boolean;
+  };
 
   private _manifest!: Manifest;
 
@@ -877,7 +884,11 @@ class EwtInstallDialog extends LitElement {
    * Return if the device runs same firmware as manifest.
    */
   private get _isSameFirmware() {
-    return this._info?.firmware === this._manifest!.name;
+    return !this._info
+      ? false
+      : this.overrides?.checkSameFirmwareVersion
+      ? this.overrides.checkSameFirmwareVersion(this._manifest, this._info)
+      : this._info.firmware === this._manifest.name;
   }
 
   /**


### PR DESCRIPTION
Tasmota has special requirements for checking if a firmware is the same. Instead of trying to implement every case a firmware has for checking if it's the same firmware, this PR allows providing your own check firmware function. The function will be provided with the manifest and the information received via Improv. 

```js
const button = document.querySelector('esp-web-install-button');
button.overrides = {
  checkSameFirmwareVersion(manifest, improvInfo) {
    const manifestFirmware = manifest.name.toLowerCase();
    const deviceFirmware = improvInfo.firmware.toLowerCase();
    return manifestFirmware.includes(deviceFirmware);
  }
};
```

Fixes #215