### PR TITLE
Make input select/textfield work better when bad REM defined

### DIFF
--- a/src/components/ewt-select.ts
+++ b/src/components/ewt-select.ts
@@ -1,5 +1,6 @@
 import { SelectBase } from "@material/mwc-select/mwc-select-base";
 import { styles } from "@material/mwc-select/mwc-select.css";
+import { css } from "lit";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -8,7 +9,15 @@ declare global {
 }
 
 export class EwtSelect extends SelectBase {
-  static override styles = [styles];
+  static override styles = [
+    styles,
+    // rem -> em conversion
+    css`
+      .mdc-floating-label {
+        line-height: 1.15em;
+      }
+    `,
+  ];
 }
 
 customElements.define("ewt-select", EwtSelect);

--- a/src/components/ewt-textfield.ts
+++ b/src/components/ewt-textfield.ts
@@ -1,5 +1,6 @@
 import { TextFieldBase } from "@material/mwc-textfield/mwc-textfield-base";
 import { styles } from "@material/mwc-textfield/mwc-textfield.css";
+import { css } from "lit";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -8,7 +9,15 @@ declare global {
 }
 
 export class EwtTextfield extends TextFieldBase {
-  static override styles = [styles];
+  static override styles = [
+    styles,
+    // rem -> em conversion
+    css`
+      .mdc-floating-label {
+        line-height: 1.15em;
+      }
+    `,
+  ];
 }
 
 customElements.define("ewt-textfield", EwtTextfield);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -20,6 +20,8 @@ export const dialogStyles = css`
     --mdc-typography-body1-line-height: 1.5em;
     --mdc-typography-button-font-size: 0.875em;
     --mdc-typography-button-line-height: 2.25em;
+    --mdc-typography-subtitle1-font-size: 1em;
+    --mdc-typography-subtitle1-line-height: 1.75em;
   }
 
   a {


### PR DESCRIPTION
Noticed on Tasmota installation page that a bad REM can still impact form fields to look bigger than they should be.

Before:

![image](https://user-images.githubusercontent.com/1444314/163267759-91e5bdae-a287-46c9-83bd-5a9c2592d892.png)

After:

![image](https://user-images.githubusercontent.com/1444314/163267878-5d49373c-cf6e-4ab4-bf99-24a35920e861.png)
