### PR TITLE
Fix chipFamily to match with esphome/build-action

### DIFF
--- a/src/flash.ts
+++ b/src/flash.ts
@@ -85,7 +85,7 @@ export const flash = async (
     return;
   }
 
-  build = manifest.builds.find((b) => b.chipFamily === chipFamily);
+  build = manifest.builds.find((b) => b.chipFamily === chipFamily.replace('-', ''));
 
   fireStateEvent({
     state: FlashStateType.MANIFEST,


### PR DESCRIPTION
The tool can't program `esp32 c3` board. Because the `chipFamily` for esp32 c3 is `ESP32-C3` not `ESP32C3`.

But repo [esphome/build-action](https://github.com/esphome/build-action) generate `manifest.json` which uses `ESP32C3`.