### PR TITLE
Bump esptool.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp-web-tools",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esp-web-tools",
-      "version": "9.0.3",
+      "version": "9.0.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17,7 +17,7 @@
         "@material/mwc-formfield": "^0.26.1",
         "@material/mwc-icon-button": "^0.26.1",
         "@material/mwc-textfield": "^0.26.1",
-        "esptool-js": "github:espressif/esptool-js#0c1b972a05d691c85da23fcc937d91dcf7e283eb",
+        "esptool-js": "github:espressif/esptool-js#076af269f44daa5b7823031221f39bf22124c129",
         "improv-wifi-serial-sdk": "^2.2.2",
         "lit": "^2.0.0",
         "pako": "^2.0.4",
@@ -1800,8 +1800,9 @@
       }
     },
     "node_modules/esptool-js": {
-      "resolved": "git+ssh://git@github.com/espressif/esptool-js.git#0c1b972a05d691c85da23fcc937d91dcf7e283eb",
-      "integrity": "sha512-axYKf6QlM1JjMvFE6MiLfNVuK0yAuRnq5UOcIN16kTE11yBDYx+zynQBDtsSxTQ+ehEnu+jPSNGC3SkgHChvcA==",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/espressif/esptool-js.git#076af269f44daa5b7823031221f39bf22124c129",
+      "integrity": "sha512-zHc9T4qC2j8EZ+1YaFRZILXxk7T1R7eA2Z2Lx1KPxgce1XbFwCsJxp4CpntytGoIDf0ax6/vbb4YArLaehVHOQ==",
       "dependencies": {
         "crypto-js": "^4.0.0",
         "xterm": "^4.13.0"
@@ -4193,9 +4194,9 @@
       "dev": true
     },
     "esptool-js": {
-      "version": "git+ssh://git@github.com/espressif/esptool-js.git#0c1b972a05d691c85da23fcc937d91dcf7e283eb",
-      "integrity": "sha512-axYKf6QlM1JjMvFE6MiLfNVuK0yAuRnq5UOcIN16kTE11yBDYx+zynQBDtsSxTQ+ehEnu+jPSNGC3SkgHChvcA==",
-      "from": "esptool-js@github:espressif/esptool-js#0c1b972a05d691c85da23fcc937d91dcf7e283eb",
+      "version": "git+ssh://git@github.com/espressif/esptool-js.git#076af269f44daa5b7823031221f39bf22124c129",
+      "integrity": "sha512-zHc9T4qC2j8EZ+1YaFRZILXxk7T1R7eA2Z2Lx1KPxgce1XbFwCsJxp4CpntytGoIDf0ax6/vbb4YArLaehVHOQ==",
+      "from": "esptool-js@github:espressif/esptool-js#076af269f44daa5b7823031221f39bf22124c129",
       "requires": {
         "crypto-js": "^4.0.0",
         "xterm": "^4.13.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@material/mwc-formfield": "^0.26.1",
     "@material/mwc-icon-button": "^0.26.1",
     "@material/mwc-textfield": "^0.26.1",
-    "esptool-js": "github:espressif/esptool-js#0c1b972a05d691c85da23fcc937d91dcf7e283eb",
+    "esptool-js": "github:espressif/esptool-js#076af269f44daa5b7823031221f39bf22124c129",
     "improv-wifi-serial-sdk": "^2.2.2",
     "lit": "^2.0.0",
     "pako": "^2.0.4",


### PR DESCRIPTION
Bump ESPTool to https://github.com/espressif/esptool-js/commit/076af269f44daa5b7823031221f39bf22124c129 to pull in latest C3 fixes.