### PR TITLE
Update the docs to automatically use latest ESP Web Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,14 +131,14 @@
     </style>
     <script
       type="module"
-      src="https://unpkg.com/@justinribeiro/lite-youtube@1.3.0/lite-youtube.js"
+      src="https://unpkg.com/@justinribeiro/lite-youtube@1.4.0/lite-youtube.js"
     ></script>
     <script module>
       import(
         // In development we import locally.
         window.location.hostname === "localhost"
           ? "/dist/web/install-button.js"
-          : "https://unpkg.com/esp-web-tools@9.2.0/dist/web/install-button.js?module"
+          : "https://unpkg.com/esp-web-tools/dist/web/install-button.js?module"
       );
     </script>
   </head>
@@ -324,7 +324,7 @@
       <pre>
 &lt;script
   type="module"
-  src="https://unpkg.com/esp-web-tools@9.2.0/dist/web/install-button.js?module"
+  src="https://unpkg.com/esp-web-tools/dist/web/install-button.js?module"
 >&lt;/script></pre
       >
       <p>


### PR DESCRIPTION
This updates the docs to automatically use the latest ESP Web Tools. Looks like unpkg with `?type=module` now works correctly.