### PR TITLE
Remove en-us from URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
       <p>
         ESP Web Tools works by combining
         <a
-          href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API"
+          href="https://developer.mozilla.org/docs/Web/API/Web_Serial_API"
           >Web Serial</a
         >, <a href="https://www.improv-wifi.com/">Improv Wi-Fi</a> (optional),
         and a manifest which describes the firmware. ESP Web Tools detects the
@@ -351,7 +351,7 @@
       <p>
         If your manifest or the firmware files are hosted on another server,
         make sure you configure
-        <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+        <a href="https://developer.mozilla.org/docs/Web/HTTP/CORS"
           >the CORS-headers</a
         >
         such that your website is allowed to fetch those files by adding the


### PR DESCRIPTION
Remove en-us from the documentation URLs