### PR TITLE
Add small delay when resetting because USB JTAG, take 2

### DIFF
--- a/src/components/ewt-console.ts
+++ b/src/components/ewt-console.ts
@@ -141,15 +141,17 @@ export class EwtConsole extends HTMLElement {
   }
 
   public async reset() {
-    this.logger.debug("Triggering reset.");
+    this.logger.debug("Triggering reset");
     await this.port.setSignals({
       dataTerminalReady: false,
       requestToSend: true,
     });
+    await sleep(250);
     await this.port.setSignals({
       dataTerminalReady: false,
       requestToSend: false,
     });
+    await sleep(250);
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 }

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -13,11 +13,12 @@ const resetTransport = async (transport: Transport) => {
     dataTerminalReady: false,
     requestToSend: true,
   });
-  await sleep(100);
+  await sleep(250);
   await transport.device.setSignals({
     dataTerminalReady: false,
     requestToSend: false,
   });
+  await sleep(250);
 };
 
 export const flash = async (


### PR DESCRIPTION
Taking one last stab with this approach, using slightly longer timings based on code I found [here](https://github.com/espressif/esptool/blob/590c2c68381b32e1d296d0b338b9d50a231169a5/esptool/reset.py#L126-L131).