### PR TITLE
Use PORT env var to customize script/develop port

### DIFF
--- a/script/develop
+++ b/script/develop
@@ -1,6 +1,10 @@
 # Stop on errors
 set -e
 
+if [ -z "$PORT" ]; then
+  PORT=5001
+fi
+
 cd "$(dirname "$0")/.."
 
 rm -rf dist
@@ -11,6 +15,6 @@ trap "kill 0" EXIT
 # Run tsc once as rollup expects those files
 npm exec -- tsc || true
 
-npm exec -- serve -p 5001 &
+npm exec -- serve -p "$PORT" &
 npm exec -- tsc --watch &
 npm exec -- rollup -c --watch


### PR DESCRIPTION
This allows the port used by `script/develop` to be customized by setting the `PORT` env var, e.g:
```
> PORT=5432 ./script/develop

   ┌────────────────────────────────────────┐
   │                                        │
   │   Serving!                             │
   │                                        │
   │   - Local:    http://localhost:5432    │
   │   - Network:  http://10.0.0.10:5432    │
   │                                        │
   │   Copied local address to clipboard!   │
   │                                        │
   └────────────────────────────────────────┘
```
Otherwise defaults to the current 5001