### PR TITLE
Add nspanelmanager project to list

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,6 +293,12 @@
           </div>
           <div class="name">TRMNL</div>
         </a>
+        <a href="https://nspanelmanager.com" target="_blank" class="project">
+          <div class="logo">
+            <img src="static/logos/nspanelmanager.svg" alt="NSPanelManager logo" />
+          </div>
+          <div class="name">NSPanel Manager</div>
+        </a>
       </div>
 
       <h2>How it works</h2>

--- a/static/logos/nspanelmanager.svg
+++ b/static/logos/nspanelmanager.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="95.541344mm"
+   height="29.999447mm"
+   viewBox="0 0 95.54134 29.999447"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="logo.svg"
+   inkscape:export-filename="/home/erik/Documents/Projekt/NSPanel Manager/Logos/logo250.png"
+   inkscape:export-xdpi="76.010269"
+   inkscape:export-ydpi="76.010269"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.3404872"
+     inkscape:cx="174.5634"
+     inkscape:cy="71.988753"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     fit-margin-top="5"
+     fit-margin-left="7"
+     fit-margin-right="7"
+     fit-margin-bottom="5" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(-23.806324,-37.155967)">
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.264583"
+       id="rect91625"
+       width="16.863066"
+       height="1.0996726"
+       x="30.938616"
+       y="59.758064" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.473039"
+       id="rect91761"
+       width="66.510048"
+       height="0.89121634"
+       x="31.042845"
+       y="42.392487" />
+    <rect
+       style="fill:#000000;stroke:#000000;stroke-width:0.34752"
+       id="rect91763"
+       width="31.46484"
+       height="1.0167363"
+       x="80.709068"
+       y="59.79953" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline"
+     transform="translate(-23.806324,-37.155967)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:0;font-family:sans-serif;letter-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="64.189873"
+       y="56.76144"
+       id="text39249"><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.4056px;line-height:0.55;font-family:Hamlin;-inkscape-font-specification:'Hamlin, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.264583"
+         x="64.189873"
+         y="56.76144"
+         id="tspan62001">NSPANEL</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93889px;line-height:1.55;font-family:Hamlin;-inkscape-font-specification:'Hamlin Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.264583"
+         x="64.189873"
+         y="62.091209"
+         id="tspan73527">MANAGER</tspan></text>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 3"
+     transform="translate(-23.806324,-37.155967)">
+    <g
+       id="g91894"
+       transform="matrix(0.15910033,0,0,0.15910033,102.25849,44.830316)">
+      <g
+         inkscape:label="Layer 1"
+         id="layer1-1"
+         transform="translate(-30.269979,-9.7200098)"
+         style="display:inline;fill:#ffc101;fill-opacity:1">
+        <path
+           style="fill:#ffc101;fill-opacity:1;stroke-width:0.103892"
+           d="m 55.789326,41.355207 -7.50621,-0.0036 c -8.143469,-0.0039 -15.508914,-0.135689 -16.902471,-0.302478 -0.482408,-0.05774 -0.940146,-0.168019 -1.017198,-0.245069 -0.115522,-0.115523 -0.121188,-0.512246 -0.03231,-2.261925 0.23677,-4.661121 1.011239,-7.815267 2.954845,-12.034057 2.163281,-4.695621 5.19604,-8.340625 9.101253,-10.938592 2.710535,-1.8032 6.982591,-3.536303 9.582241,-3.887359 0.270422,-0.03652 0.543941,-0.129371 0.60782,-0.20634 0.06388,-0.07697 0.286764,-0.168201 0.495299,-0.202735 0.208537,-0.03453 0.449284,-0.09017 0.534995,-0.123628 0.168484,-0.06577 0.381034,-0.08553 1.215776,-0.112981 l 0.540477,-0.01778 0.03093,-0.649326 0.03093,-0.6493272 h 1.610329 1.610329 l 0.03093,0.6493272 0.03093,0.649326 0.540477,0.01778 c 0.834742,0.02745 1.047292,0.04721 1.215776,0.112981 0.08571,0.03346 0.326458,0.08909 0.534995,0.123628 0.208535,0.03453 0.43142,0.125765 0.495299,0.202735 0.06388,0.07697 0.337398,0.169823 0.60782,0.20634 1.199505,0.161981 3.423686,0.820696 4.997483,1.480058 3.507719,1.469604 6.221358,3.303143 8.667596,5.856479 2.140092,2.233788 3.602852,4.416791 5.018415,7.489412 1.943606,4.21879 2.718075,7.372936 2.954845,12.034057 0.08888,1.749679 0.08321,2.146402 -0.03231,2.261925 -0.07705,0.07705 -0.53479,0.187332 -1.017198,0.245069 -1.393557,0.166789 -8.759002,0.298597 -16.902471,0.302478 l -7.50621,0.0036 z"
+           id="path1465"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="15.183412"
+           inkscape:export-ydpi="15.183412"
+           sodipodi:nodetypes="csssssssssscccccccccscssssssssccc" />
+      </g>
+      <g
+         inkscape:label="Layer 1 copy"
+         id="g2878"
+         transform="translate(-30.269979,-9.7200098)"
+         style="display:inline">
+        <path
+           style="fill:#000000;fill-opacity:1;stroke-width:0.103892"
+           d="m 54.334834,101.13608 c -3.956539,-0.21732 -5.98252,-0.58093 -6.463066,-1.159955 -0.09761,-0.11762 -0.123549,-0.57148 -0.09916,-1.73541 0.02799,-1.33577 0.008,-1.59689 -0.130816,-1.71212 -0.09011,-0.0748 -0.16384,-0.29294 -0.16384,-0.48477 0,-0.30436 0.05486,-0.37678 0.430667,-0.5685 0.694102,-0.3541 2.301256,-0.71174 4.060659,-0.9036 l 1.638312,-0.17866 V 70.783119 c 0,-15.670705 -0.03494,-23.609951 -0.103892,-23.609951 -0.05714,0 -0.103892,-0.0935 -0.103892,-0.207784 0,-0.194592 0.06926,-0.207784 1.090868,-0.207784 0.900399,0 1.090868,-0.02721 1.090868,-0.155839 0,-0.08571 0.04675,-0.155838 0.103892,-0.155838 0.06644,0 0.103892,-3.463072 0.103892,-5.090716 l 2.493412,-2e-6 c 0,1.627644 0.03746,5.090716 0.103892,5.090716 0.05714,0 0.103892,0.07013 0.103892,0.155838 0,0.128629 0.190469,0.155839 1.090868,0.155839 1.021606,0 1.090868,0.01319 1.090868,0.207784 0,0.114281 -0.04675,0.207784 -0.103892,0.207784 -0.06896,0 -0.103892,7.939246 -0.103892,23.609951 v 23.609948 l 1.638312,0.17866 c 1.759403,0.19186 3.366557,0.54949 4.060659,0.9036 0.375812,0.19172 0.430667,0.26413 0.430667,0.5685 0,0.19183 -0.07373,0.40998 -0.16384,0.48476 -0.138668,0.11509 -0.158971,0.37643 -0.132144,1.70097 0.01743,0.86075 -0.0055,1.62411 -0.05099,1.69635 -0.27864,0.442605 -1.632284,0.804945 -3.803075,1.017985 -1.460176,0.14331 -6.726732,0.26812 -8.109225,0.19219 z"
+           id="path2876"
+           inkscape:connector-curvature="0"
+           inkscape:export-xdpi="15.183412"
+           inkscape:export-ydpi="15.183412"
+           sodipodi:nodetypes="ssssssscssssssccsssssscssssscsss" />
+      </g>
+      <g
+         id="layer3-5"
+         inkscape:label="Layer 3">
+        <circle
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:17.1351;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           id="path1510"
+           cx="34.837666"
+           cy="55.072739"
+           r="1.2872558" />
+      </g>
+      <g
+         id="layer2-9"
+         inkscape:label="Layer 2">
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:12.8043;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+           id="rect1508"
+           width="1.3904994"
+           height="22.681686"
+           x="34.147842"
+           y="31.601988" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Dear esp-web-tools maintainers, thanks for making the esp-web-tools, it definitely improved the user experience of our end users in the project NSPanel Manager: https://nspanelmanager.com/

We added a link and credit to esp-web-tools in the flashing page: https://nspanelmanager.com/flashing-tool.html `Installer powered by ESP Web Tools.`

Would be awesome if you would also accept to add the NSPanel Manager logo to the list of products using esp-web-tools 👍 
