### PR TITLE
Performance improvements + line break fix

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -21,7 +21,7 @@ export const connect = async (button: InstallButton) => {
   }
 
   try {
-    await port.open({ baudRate: 115200 });
+    await port.open({ baudRate: 115200, bufferSize: 8192 });
   } catch (err: any) {
     alert(err.message);
     return;

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -923,13 +923,13 @@ export class EwtInstallDialog extends LitElement {
         if (state.state === FlashStateType.FINISHED) {
           sleep(100)
             // Flashing closes the port
-            .then(() => this.port.open({ baudRate: 115200 }))
+            .then(() => this.port.open({ baudRate: 115200, bufferSize: 8192 }))
             .then(() => this._initialize(true))
             .then(() => this.requestUpdate());
         } else if (state.state === FlashStateType.ERROR) {
           sleep(100)
             // Flashing closes the port
-            .then(() => this.port.open({ baudRate: 115200 }));
+            .then(() => this.port.open({ baudRate: 115200, bufferSize: 8192 }));
         }
       },
       this.port,

--- a/src/util/line-break-transformer.ts
+++ b/src/util/line-break-transformer.ts
@@ -8,7 +8,7 @@ export class LineBreakTransformer implements Transformer<string, string> {
     // Append new chunks to existing chunks.
     this.chunks += chunk;
     // For each line breaks in chunks, send the parsed lines out.
-    const lines = this.chunks.split("\r\n");
+    const lines = this.chunks.split(/\r?\n/);
     this.chunks = lines.pop()!;
     lines.forEach((line) => controller.enqueue(line + "\r\n"));
   }


### PR DESCRIPTION
- fix line breaks, look for both \r\n and \n
- increase buffer size for serial from 255 to 8192
- fix performance issues in the log console which caused delayed logging or the page to become unresponsive
- resolves https://github.com/esphome/esp-web-tools/issues/448
- resolves https://github.com/esphome/esp-web-tools/issues/545