### PR TITLE
Update esptool-js to version 0.5.6 to support ESP32C5

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@ esptool --chip esp32 merge_bin \
         install. It allows specifying different builds for the different types
         of ESP devices. Current supported chip families are
         <code>ESP8266</code>, <code>ESP32</code>, <code>ESP32-C2</code>,
-        <code>ESP32-C3</code>, <code>ESP32-C6</code>, <code>ESP32-H2</code>,
+        <code>ESP32-C3</code>, <code>ESP32-C5</code>, <code>ESP32-C6</code>, <code>ESP32-H2</code>,
         <code>ESP32-S2</code> and <code>ESP32-S3</code>. The correct build will
         be automatically selected based on the type of the connected ESP device.
       </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@material/web": "^2.2.0",
-        "esptool-js": "^0.5.3",
+        "esptool-js": "^0.5.6",
         "improv-wifi-serial-sdk": "^2.5.0",
         "lit": "^3.2.1",
         "pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@material/web": "^2.2.0",
-    "esptool-js": "^0.5.3",
+    "esptool-js": "^0.5.6",
     "improv-wifi-serial-sdk": "^2.5.0",
     "lit": "^3.2.1",
     "pako": "^2.1.0",

--- a/src/const.ts
+++ b/src/const.ts
@@ -9,6 +9,7 @@ export interface Build {
     | "ESP32"
     | "ESP32-C2"
     | "ESP32-C3"
+    | "ESP32-C5"
     | "ESP32-C6"
     | "ESP32-H2"
     | "ESP32-S2"


### PR DESCRIPTION
esptool-js version 0.5.6 supports (tested on esp32c5)