### PR TITLE
Use OIDC when publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -21,4 +21,4 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance


### PR DESCRIPTION
When we added trusted publishing, we forgot to tell npm to use the OIDC credentials.

CC @stvncode 