### PR TITLE
Increase SSID scan retry delay to 2 seconds

### DIFF
--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -791,7 +791,7 @@ export class EwtInstallDialog extends LitElement {
     // We will retry a few times if we don't get any results
     if (ssids.length === 0 && tries < 3) {
       console.log("SCHEDULE RETRY", tries);
-      setTimeout(() => this._updateSsids(tries + 1), 1000);
+      setTimeout(() => this._updateSsids(tries + 1), 2000);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Increases the delay between SSID scan retries from 1 second to 2 seconds when zero networks are found during improv post-install provisioning
- Gives devices more time to complete their network scan before retrying

## Test plan
- [x] Flash a device and go through improv provisioning flow
- [x] Verify retries occur with 2 second delays if no networks found initially

🤖 Generated with [Claude Code](https://claude.com/claude-code)