### PR TITLE
Add serialType field to auto-select CDC vs UART firmware variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Allow flashing ESPHome or other ESP-based firmwares via the browser. Will automa
 
 Example manifest:
 
+The optional `serialType` field (`"cdc"` or `"uart"`) lets you ship separate firmware variants for chips that support both native USB CDC (built-in USB) and external USB-to-UART bridges. The correct variant is selected automatically based on the detected connection. Builds without a `serialType` are used as a fallback for any connection type.
+
 ```json
 {
   "name": "ESPHome",
@@ -46,11 +48,22 @@ Example manifest:
     },
     {
       "chipFamily": "ESP32-S3",
+      "serialType": "uart",
       "parts": [
         { "path": "bootloader_dout_40m.bin", "offset": 4096 },
         { "path": "partitions.bin", "offset": 32768 },
         { "path": "boot_app0.bin", "offset": 57344 },
         { "path": "esp32-s3.bin", "offset": 65536 }
+      ]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "serialType": "cdc",
+      "parts": [
+        { "path": "bootloader_dout_40m.bin", "offset": 4096 },
+        { "path": "partitions.bin", "offset": 32768 },
+        { "path": "boot_app0.bin", "offset": 57344 },
+        { "path": "esp32-s3-cdc.bin", "offset": 65536 }
       ]
     },
     {

--- a/src/const.ts
+++ b/src/const.ts
@@ -21,6 +21,16 @@ export interface Build {
     path: string;
     offset: number;
   }[];
+  /**
+   * Optional serial transport type for this build variant.
+   * - `"cdc"`: Native USB CDC (e.g. ESP32-S2/S3/C3 built-in USB)
+   * - `"uart"`: External USB-to-UART bridge (e.g. CP2102, CH340)
+   * - absent: No transport preference; matches any connection as a fallback.
+   *
+   * Build selection tries an exact `serialType` match first, then falls back to a build
+   * with no `serialType`. If neither is found, installation is refused.
+   */
+  serialType?: "cdc" | "uart";
 }
 
 export interface Manifest {

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -38,6 +38,17 @@ export const flash = async (
     });
 
   const transport = new Transport(port);
+
+  // Detect native USB CDC by checking Espressif's USB vendor ID (0x303a) and
+  // known CDC product IDs for chips with built-in USB (ESP32-S2, S3, C3, etc.).
+  // Devices connected via an external USB-to-UART bridge will not match.
+  const portInfo = port.getInfo();
+  const isCdcUsbPort =
+    portInfo &&
+    portInfo.usbVendorId === 0x303a &&
+    portInfo.usbProductId !== undefined &&
+    [0x1001, 0x1002, 0x1003, 0x0002, 0x0003].includes(portInfo.usbProductId);
+
   const esploader = new ESPLoader({
     transport,
     baudrate: 115200,
@@ -79,7 +90,14 @@ export const flash = async (
     details: { done: true },
   });
 
-  build = manifest.builds.find((b) => b.chipFamily === chipFamily);
+  // Select the build for this chip, preferring an exact serialType match for the
+  // detected connection (CDC for native USB, UART otherwise), then falling back to
+  // a build with no serialType specified. If neither is found, the "not supported"
+  // error fires below.
+  const detectedSerialType = isCdcUsbPort ? "cdc" : "uart";
+  build =
+    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType) ||
+    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === undefined);
 
   if (!build) {
     fireStateEvent({

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -96,8 +96,12 @@ export const flash = async (
   // error fires below.
   const detectedSerialType = isCdcUsbPort ? "cdc" : "uart";
   build =
-    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType) ||
-    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === undefined);
+    manifest.builds.find(
+      (b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType,
+    ) ||
+    manifest.builds.find(
+      (b) => b.chipFamily === chipFamily && b.serialType === undefined,
+    );
 
   if (!build) {
     fireStateEvent({


### PR DESCRIPTION
## Summary

- Adds an optional `serialType: "cdc" | "uart"` field to the `Build` interface in the manifest schema
- Detects whether the connected device uses native USB CDC (Espressif VID `0x303a`) or an external USB-to-UART bridge via `port.getInfo()`
- Automatically selects the matching firmware variant when multiple builds share the same `chipFamily`

## Motivation

Chips like ESP32-S3 and ESP32-C3 can be connected either via their built-in USB CDC port or via an external USB-to-UART bridge. These two connection methods require different firmware builds (different compile flags). Previously, users had to manually choose the correct variant — or the wrong firmware could be flashed silently.

This was originally requested in #383, which was closed with the conclusion that detecting the connection type was not possible. However, `port.getInfo()` from the Web Serial API does expose the USB vendor and product IDs before any communication begins, making detection straightforward. Espressif's native USB CDC devices are identifiable by VID `0x303a` and known CDC product IDs, as noted in the discussion on #383 itself.

The Tasmota approach (single firmware that detects CDC at runtime) is a valid alternative, but is not always available — particularly for projects that need separate binaries for each transport type. This feature is purely additive and requires no changes for projects that don't need it.

## Behavior

Build selection priority:
1. **Exact match**: build with `chipFamily` + `serialType` matching the detected connection
2. **Generic fallback**: build with `chipFamily` and no `serialType` specified
3. **Not supported**: if neither is found, installation is refused — avoiding silently flashing the wrong transport variant

Manifests without `serialType` are completely unaffected — existing single-variant manifests continue to work as before.

## Example manifest

```json
{
  "chipFamily": "ESP32-S3",
  "serialType": "uart",
  "parts": [...]
},
{
  "chipFamily": "ESP32-S3",
  "serialType": "cdc",
  "parts": [...]
}
```

Closes #383
Related: #331