### PR TITLE
Support for hardware qualifiers (Flash + PSRAM) in manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,42 @@ Example manifest:
 }
 ```
 
+Builds can optionally include `flashSizeMB` and `psramSizeMB` to target specific hardware variants. When multiple builds share the same `chipFamily`, the most specific match wins:
+
+```json
+{
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "flashSizeMB": 16,
+      "psramSizeMB": 8,
+      "parts": [{ "path": "s3-16mb-8psram.bin", "offset": 0 }]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "flashSizeMB": 4,
+      "parts": [{ "path": "s3-4mb.bin", "offset": 0 }]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [{ "path": "s3-generic.bin", "offset": 0 }]
+    }
+  ]
+}
+```
+
+A build with no qualifiers acts as a fallback for that chip family.
+
+## Diagnostics
+
+ESP Web Tools includes a diagnostics button that reads hardware information from a connected ESP device without installing any firmware:
+
+```html
+<esp-web-diagnostics-button></esp-web-diagnostics-button>
+```
+
+This displays the chip description, features, crystal frequency, MAC address, flash size, and PSRAM size. Like the install button, it supports `activate`, `unsupported`, and `not-allowed` slots for customization, and uses the same CSS custom properties for styling.
+
 ## Development
 
 Run `script/develop`. This starts a server. Open it on http://localhost:5001.

--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
         <li>Connect device to the Wi-Fi network</li>
         <li>Visit the device's hosted web interface</li>
         <li>Access logs and send terminal commands</li>
+        <li>Read device hardware information (chip, flash, PSRAM)</li>
         <li>
           Add devices to
           <a href="https://www.home-assistant.io">Home Assistant</a>
@@ -347,8 +348,9 @@
           >Web Serial</a
         >, <a href="https://www.improv-wifi.com/">Improv Wi-Fi</a> (optional),
         and a manifest which describes the firmware. ESP Web Tools detects the
-        chipset of the connected ESP device and automatically selects the right
-        firmware variant from the manifest.
+        chipset, flash size, and PSRAM of the connected ESP device and
+        automatically selects the best matching firmware variant from the
+        manifest.
       </p>
       <p>
         Web Serial is available in Google Chrome and Microsoft Edge
@@ -532,6 +534,53 @@ esptool --chip esp32 merge_bin \
         where it should be installed. Part paths are resolved relative to the
         path of the manifest, but can also be URLs to other hosts.
       </p>
+
+      <h4>Hardware qualifiers</h4>
+      <p>
+        Builds can optionally include <code>flashSizeMB</code> and
+        <code>psramSizeMB</code> to target specific hardware variants within the
+        same chip family. ESP Web Tools detects the connected device's flash size
+        and PSRAM size and selects the most specific matching build.
+      </p>
+      <pre>
+{
+  "name": "My Firmware",
+  "version": "1.0.0",
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "flashSizeMB": 16,
+      "psramSizeMB": 8,
+      "parts": [{ "path": "s3-16mb-8psram.bin", "offset": 0 }]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "flashSizeMB": 4,
+      "parts": [{ "path": "s3-4mb.bin", "offset": 0 }]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [{ "path": "s3-generic.bin", "offset": 0 }]
+    }
+  ]
+}</pre
+      >
+      <p>
+        The matching algorithm uses a most-specific-match-wins approach:
+      </p>
+      <ul>
+        <li>
+          A build whose qualifier does <em>not</em> match the device is excluded
+          (e.g. a build requiring 16 MB flash won't match a 4 MB device).
+        </li>
+        <li>
+          Among remaining builds, the one with the most matching qualifiers wins.
+        </li>
+        <li>Ties are broken by manifest order (first wins).</li>
+        <li>
+          A build with no qualifiers acts as a fallback for that chip family.
+        </li>
+      </ul>
       <p>
         If your firmware is supported by Home Assistant, you can add the
         optional key <code>home_assistant_domain</code>. If present, ESP Web
@@ -668,6 +717,35 @@ document.querySelector("esp-web-install-button").manifest = URL.createObjectURL(
 &lt;/esp-web-install-button>
     </pre
       >
+
+      <h3 id="diagnostics">Diagnostics button</h3>
+      <p>
+        ESP Web Tools also includes a diagnostics button that reads hardware
+        information from a connected ESP device without installing any firmware.
+        It displays the chip description, features, crystal frequency, MAC
+        address, flash size, and PSRAM size.
+      </p>
+      <p>
+        Load the diagnostics button JavaScript on your website:
+      </p>
+      <pre>
+&lt;script
+  type="module"
+  src="https://unpkg.com/esp-web-tools@10/dist/web/diagnostics-button.js?module"
+>&lt;/script></pre
+      >
+      <p>Then add the button element:</p>
+      <pre>
+&lt;esp-web-diagnostics-button>&lt;/esp-web-diagnostics-button></pre
+      >
+      <p>
+        Like the install button, you can customize it using the
+        <code>activate</code>, <code>unsupported</code>, and
+        <code>not-allowed</code> slots, and the same CSS custom properties
+        (<code>--esp-tools-button-color</code>,
+        <code>--esp-tools-button-text-color</code>,
+        <code>--esp-tools-button-border-radius</code>).
+      </p>
 
       <h2>Why we created ESP Web Tools</h2>
       <div class="videoWrapper">

--- a/index.html
+++ b/index.html
@@ -143,6 +143,11 @@
           ? "/dist/web/install-button.js"
           : "https://unpkg.com/esp-web-tools/dist/web/install-button.js?module"
       );
+      import(
+        window.location.hostname === "localhost"
+          ? "/dist/web/diagnostics-button.js"
+          : "https://unpkg.com/esp-web-tools/dist/web/diagnostics-button.js?module"
+      );
     </script>
   </head>
   <body>
@@ -186,6 +191,16 @@
           >.
         </i>
       </esp-web-install-button>
+      <p>
+        You can also read hardware information from a connected ESP device
+        without installing any firmware:
+      </p>
+      <esp-web-diagnostics-button>
+        <i slot="unsupported">
+          Diagnostics are not available because your browser does not support
+          Web Serial. Open this page in Google Chrome or Microsoft Edge instead.
+        </i>
+      </esp-web-diagnostics-button>
 
       <h2 id="used-by">Products using ESP Web Tools</h2>
       <div class="projects">

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,7 @@ import babel from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs";
 
 const config = {
-  input: "dist/install-button.js",
+  input: ["dist/install-button.js", "dist/diagnostics-button.js"],
   output: {
     dir: "dist/web",
     format: "module",

--- a/src/const.ts
+++ b/src/const.ts
@@ -17,6 +17,8 @@ export interface Build {
     | "ESP32-S2"
     | "ESP32-S3"
     | "ESP8266";
+  flashSizeMB?: number;
+  psramSizeMB?: number;
   parts: {
     path: string;
     offset: number;

--- a/src/diagnostics-button.ts
+++ b/src/diagnostics-button.ts
@@ -1,0 +1,138 @@
+export class DiagnosticsButton extends HTMLElement {
+  public static isSupported = "serial" in navigator;
+
+  public static isAllowed = window.isSecureContext;
+
+  private static style = `
+  button {
+    position: relative;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 10px 24px;
+    color: var(--esp-tools-button-text-color, #fff);
+    background-color: var(--esp-tools-button-color, #03a9f4);
+    border: none;
+    border-radius: var(--esp-tools-button-border-radius, 9999px);
+  }
+  button::before {
+    content: " ";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0.2;
+    border-radius: var(--esp-tools-button-border-radius, 9999px);
+  }
+  button:hover::before {
+    background-color: rgba(255,255,255,.8);
+  }
+  button:focus {
+    outline: none;
+  }
+  button:focus::before {
+    background-color: white;
+  }
+  button:active::before {
+    background-color: grey;
+  }
+  :host([active]) button {
+    color: rgba(0, 0, 0, 0.38);
+    background-color: rgba(0, 0, 0, 0.12);
+    box-shadow: none;
+    cursor: unset;
+    pointer-events: none;
+  }
+  .hidden {
+    display: none;
+  }`;
+
+  public renderRoot?: ShadowRoot;
+
+  public connectedCallback() {
+    if (this.renderRoot) {
+      return;
+    }
+
+    this.renderRoot = this.attachShadow({ mode: "open" });
+
+    if (!DiagnosticsButton.isSupported || !DiagnosticsButton.isAllowed) {
+      this.toggleAttribute("install-unsupported", true);
+      this.renderRoot.innerHTML = !DiagnosticsButton.isAllowed
+        ? "<slot name='not-allowed'>You can only use this on HTTPS websites or on localhost.</slot>"
+        : "<slot name='unsupported'>Your browser does not support Web Serial. Use Google Chrome or Microsoft Edge.</slot>";
+      return;
+    }
+
+    this.toggleAttribute("install-supported", true);
+
+    const slot = document.createElement("slot");
+
+    slot.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      this._connect();
+    });
+
+    slot.name = "activate";
+    const button = document.createElement("button");
+    button.innerText = "Diagnostics";
+    slot.append(button);
+
+    if (
+      "adoptedStyleSheets" in Document.prototype &&
+      "replaceSync" in CSSStyleSheet.prototype
+    ) {
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(DiagnosticsButton.style);
+      this.renderRoot.adoptedStyleSheets = [sheet];
+    } else {
+      const styleSheet = document.createElement("style");
+      styleSheet.innerText = DiagnosticsButton.style;
+      this.renderRoot.append(styleSheet);
+    }
+    this.renderRoot.append(slot);
+  }
+
+  private async _connect() {
+    import("./diagnostics-dialog.js");
+    let port: SerialPort | undefined;
+    try {
+      port = await navigator.serial.requestPort();
+    } catch (err: any) {
+      if ((err as DOMException).name !== "NotFoundError") {
+        alert(`Error: ${err.message}`);
+      }
+      return;
+    }
+
+    if (!port) {
+      return;
+    }
+
+    try {
+      await port.open({ baudRate: 115200, bufferSize: 8192 });
+    } catch (err: any) {
+      alert(err.message);
+      return;
+    }
+
+    const el = document.createElement("ewt-diagnostics-dialog");
+    (el as any).port = port;
+    el.addEventListener(
+      "closed",
+      async () => {
+        // Port is closed by the dialog via transport.disconnect(); ignore if already closed.
+        try {
+          await port!.close();
+        } catch {
+          // already closed
+        }
+      },
+      { once: true },
+    );
+    document.body.appendChild(el);
+  }
+}
+
+customElements.define("esp-web-diagnostics-button", DiagnosticsButton);

--- a/src/diagnostics-dialog.ts
+++ b/src/diagnostics-dialog.ts
@@ -1,0 +1,258 @@
+import { LitElement, html, css, TemplateResult } from "lit";
+import { state } from "lit/decorators.js";
+import { Transport, ESPLoader } from "esptool-js";
+import "./components/ew-dialog";
+import "./components/ew-text-button";
+import "./components/ew-icon-button";
+import "./pages/ewt-page-progress";
+import "./pages/ewt-page-message";
+import { closeIcon } from "./components/svg";
+import { fireEvent } from "./util/fire-event";
+import { parsePsramSizeFromFeatures } from "./util/build-match";
+import { sleep } from "./util/sleep";
+import { dialogStyles } from "./styles";
+
+interface HardwareInfo {
+  chipDescription: string;
+  chipFeatures: string[];
+  crystalFreqMhz: number;
+  mac: string;
+  flashSizeMB: number | null;
+  psramSizeMB: number | null;
+}
+
+export class EwtDiagnosticsDialog extends LitElement {
+  public port!: SerialPort;
+
+  @state() private _state: "LOADING" | "INFO" | "ERROR" = "LOADING";
+  @state() private _info?: HardwareInfo;
+  @state() private _error?: string;
+
+  private _bodyOverflow: string | null = null;
+
+  protected override render() {
+    let heading: string | undefined;
+    let content: TemplateResult;
+    let allowClosing = false;
+
+    if (this._state === "LOADING") {
+      content = html`
+        <ewt-page-progress
+          slot="content"
+          .label=${"Reading hardware info..."}
+        ></ewt-page-progress>
+      `;
+    } else if (this._state === "ERROR") {
+      heading = "Error";
+      allowClosing = true;
+      content = html`
+        <ewt-page-message
+          slot="content"
+          .icon=${"⚠️"}
+          .label=${this._error!}
+        ></ewt-page-message>
+        <div slot="actions">
+          <ew-text-button @click=${this._closeDialog}>Close</ew-text-button>
+        </div>
+      `;
+    } else {
+      heading = "Hardware Info";
+      allowClosing = true;
+      const info = this._info!;
+      content = html`
+        <div slot="content">
+          <div class="info-table">
+            <div class="row">
+              <span class="label">Chip</span>
+              <span class="value">${info.chipDescription}</span>
+            </div>
+            <div class="row">
+              <span class="label">Features</span>
+              <span class="value">${info.chipFeatures.join(", ") || "—"}</span>
+            </div>
+            <div class="row">
+              <span class="label">Crystal</span>
+              <span class="value">${info.crystalFreqMhz} MHz</span>
+            </div>
+            <div class="row">
+              <span class="label">MAC Address</span>
+              <span class="value">${info.mac}</span>
+            </div>
+            <div class="row">
+              <span class="label">Flash Size</span>
+              <span class="value"
+                >${info.flashSizeMB != null
+                  ? `${info.flashSizeMB} MB`
+                  : "Unknown"}</span
+              >
+            </div>
+            <div class="row">
+              <span class="label">PSRAM Size</span>
+              <span class="value"
+                >${info.psramSizeMB != null
+                  ? `${info.psramSizeMB} MB`
+                  : "Not detected"}</span
+              >
+            </div>
+          </div>
+        </div>
+        <div slot="actions">
+          <ew-text-button @click=${this._closeDialog}>Close</ew-text-button>
+        </div>
+      `;
+    }
+
+    return html`
+      <ew-dialog
+        open
+        .heading=${heading!}
+        @cancel=${this._preventDefault}
+        @closed=${this._handleClose}
+      >
+        ${heading ? html`<div slot="headline">${heading}</div>` : ""}
+        ${allowClosing
+          ? html`
+              <ew-icon-button slot="headline" @click=${this._closeDialog}>
+                ${closeIcon}
+              </ew-icon-button>
+            `
+          : ""}
+        ${content}
+      </ew-dialog>
+    `;
+  }
+
+  protected override async firstUpdated() {
+    this._bodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    await this._readHardwareInfo();
+  }
+
+  private async _readHardwareInfo() {
+    // ESPLoader opens the port itself, so close it first.
+    await this.port.close();
+
+    const transport = new Transport(this.port);
+    const esploader = new ESPLoader({
+      transport,
+      baudrate: 115200,
+      romBaudrate: 115200,
+      enableTracing: false,
+    });
+
+    try {
+      await esploader.main();
+      await esploader.flashId();
+    } catch (err: any) {
+      this._state = "ERROR";
+      this._error =
+        "Failed to connect. Try resetting your device or holding the BOOT button while connecting.";
+      await transport.disconnect();
+      return;
+    }
+
+    try {
+      const chipDescription =
+        await esploader.chip.getChipDescription(esploader);
+      const chipFeatures = await esploader.chip.getChipFeatures(esploader);
+      const crystalFreqMhz = await esploader.chip.getCrystalFreq(esploader);
+      const mac = await esploader.chip.readMac(esploader);
+      let flashSizeMB: number | null = null;
+      try {
+        const flashKB = await esploader.getFlashSize();
+        flashSizeMB = flashKB / 1024;
+      } catch {
+        // flash size unavailable on some chips
+      }
+      const psramSizeMB = parsePsramSizeFromFeatures(chipFeatures) ?? null;
+
+      this._info = {
+        chipDescription,
+        chipFeatures,
+        crystalFreqMhz,
+        mac,
+        flashSizeMB,
+        psramSizeMB,
+      };
+      this._state = "INFO";
+    } catch (err: any) {
+      this._state = "ERROR";
+      this._error = `Failed to read hardware info: ${err.message}`;
+    }
+
+    try {
+      await transport.setRTS(true);
+      await sleep(100);
+      await esploader.after();
+    } catch {
+      // ignore reset errors
+    }
+    await transport.disconnect();
+  }
+
+  private _closeDialog() {
+    this.shadowRoot!.querySelector("ew-dialog")!.close();
+  }
+
+  private async _handleClose() {
+    fireEvent(this, "closed" as any);
+    document.body.style.overflow = this._bodyOverflow!;
+    this.parentNode!.removeChild(this);
+  }
+
+  private _preventDefault(ev: Event) {
+    ev.preventDefault();
+  }
+
+  static styles = [
+    dialogStyles,
+    css`
+      :host {
+        --mdc-dialog-max-width: 390px;
+      }
+      div[slot="headline"] {
+        padding-right: 48px;
+      }
+      ew-icon-button[slot="headline"] {
+        position: absolute;
+        right: 4px;
+        top: 8px;
+      }
+      ew-icon-button[slot="headline"] svg {
+        padding: 8px;
+        color: var(--text-color);
+      }
+      .info-table {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 4px 0;
+      }
+      .row {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .label {
+        font-size: 11px;
+        color: var(--text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .value {
+        font-size: 14px;
+        color: rgba(0, 0, 0, 0.87);
+        font-family: monospace;
+        word-break: break-all;
+      }
+    `,
+  ];
+}
+
+customElements.define("ewt-diagnostics-dialog", EwtDiagnosticsDialog);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ewt-diagnostics-dialog": EwtDiagnosticsDialog;
+  }
+}

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -6,6 +6,11 @@ import {
   Manifest,
   FlashStateType,
 } from "./const";
+import {
+  detectHardware,
+  findBestBuild,
+  DetectedHardware,
+} from "./util/build-match";
 import { sleep } from "./util/sleep";
 
 /**
@@ -73,13 +78,32 @@ export const flash = async (
 
   chipFamily = esploader.chip.CHIP_NAME as any;
 
+  let detectedHardware: DetectedHardware = { chipFamily };
+
+  try {
+    detectedHardware = await detectHardware(esploader, chipFamily);
+  } catch (err) {
+    console.warn(
+      "Hardware detection failed, falling back to chipFamily-only match:",
+      err,
+    );
+  }
+
+  const hwParts: string[] = [chipFamily];
+  if (detectedHardware.flashSizeMB != null) {
+    hwParts.push(`${detectedHardware.flashSizeMB}MB flash`);
+  }
+  if (detectedHardware.psramSizeMB != null) {
+    hwParts.push(`${detectedHardware.psramSizeMB}MB PSRAM`);
+  }
+
   fireStateEvent({
     state: FlashStateType.INITIALIZING,
-    message: `Initialized. Found ${chipFamily}`,
+    message: `Initialized. Found ${hwParts.join(", ")}`,
     details: { done: true },
   });
 
-  build = manifest.builds.find((b) => b.chipFamily === chipFamily);
+  build = findBestBuild(manifest.builds, detectedHardware);
 
   if (!build) {
     fireStateEvent({

--- a/src/util/build-match.ts
+++ b/src/util/build-match.ts
@@ -1,0 +1,89 @@
+import { Build } from "../const";
+import { ESPLoader } from "esptool-js";
+
+export interface DetectedHardware {
+  chipFamily: Build["chipFamily"];
+  flashSizeMB?: number;
+  psramSizeMB?: number;
+}
+
+/**
+ * Parse PSRAM size in MB from chip features array.
+ * Returns undefined if no size can be determined.
+ */
+export const parsePsramSizeFromFeatures = (
+  features: string[],
+): number | undefined => {
+  for (const feature of features) {
+    const match = feature.match(/Embedded PSRAM (\d+)MB/i);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Query flash size and chip features from the device.
+ */
+export const detectHardware = async (
+  esploader: ESPLoader,
+  chipFamily: Build["chipFamily"],
+): Promise<DetectedHardware> => {
+  const [flashKB, features] = await Promise.all([
+    esploader.getFlashSize(),
+    esploader.chip.getChipFeatures(esploader),
+  ]);
+
+  return {
+    chipFamily,
+    flashSizeMB: flashKB / 1024,
+    psramSizeMB: parsePsramSizeFromFeatures(features),
+  };
+};
+
+/**
+ * Find the best matching build using most-specific-match-wins algorithm.
+ *
+ * - A build whose qualifier does NOT match the device is excluded
+ * - Among remaining builds, the one with the most matching qualifiers wins
+ * - Ties broken by manifest order (first wins)
+ * - A build with no qualifiers (score 0) is the fallback
+ */
+export const findBestBuild = (
+  builds: Build[],
+  hw: DetectedHardware,
+): Build | undefined => {
+  let bestBuild: Build | undefined;
+  let bestScore = -1;
+
+  for (const b of builds) {
+    if (b.chipFamily !== hw.chipFamily) continue;
+
+    let score = 0;
+    let excluded = false;
+
+    if (b.flashSizeMB != null) {
+      if (hw.flashSizeMB != null && b.flashSizeMB === hw.flashSizeMB) {
+        score++;
+      } else {
+        excluded = true;
+      }
+    }
+
+    if (b.psramSizeMB != null) {
+      if (hw.psramSizeMB != null && b.psramSizeMB === hw.psramSizeMB) {
+        score++;
+      } else {
+        excluded = true;
+      }
+    }
+
+    if (!excluded && score > bestScore) {
+      bestScore = score;
+      bestBuild = b;
+    }
+  }
+
+  return bestBuild;
+};

--- a/src/util/manifest.ts
+++ b/src/util/manifest.ts
@@ -14,5 +14,26 @@ export const downloadManifest = async (manifestPath: string) => {
     }
   }
 
+  for (const build of manifest.builds) {
+    if (
+      build.flashSizeMB != null &&
+      (typeof build.flashSizeMB !== "number" || build.flashSizeMB <= 0)
+    ) {
+      console.warn(
+        `Manifest build for ${build.chipFamily} has invalid flashSizeMB: ${build.flashSizeMB}. Ignoring.`,
+      );
+      delete build.flashSizeMB;
+    }
+    if (
+      build.psramSizeMB != null &&
+      (typeof build.psramSizeMB !== "number" || build.psramSizeMB <= 0)
+    ) {
+      console.warn(
+        `Manifest build for ${build.chipFamily} has invalid psramSizeMB: ${build.psramSizeMB}. Ignoring.`,
+      );
+      delete build.psramSizeMB;
+    }
+  }
+
   return manifest;
 };


### PR DESCRIPTION
Allow for more fine grained targeting to sepcific hardware. The ESP32-S3 modules, for example, comes with several configurations of flash and PSRAM and this PR makes it possible to target them individually.

Summary

  - Add flashSizeMB and psramSizeMB optional qualifiers to manifest builds, enabling firmware targeting by hardware variant within the same chip family
  - Detect flash size and PSRAM on connect and select the most specific matching build (most-qualifiers-wins, with fallback to unqualified builds)
  - Add <esp-web-diagnostics-button> component that reads and displays chip, flash, PSRAM, crystal frequency, and MAC address without flashing
  - Validate and strip invalid qualifier values at manifest load time
  - Document hardware qualifiers and diagnostics button in README and website

  Manifest example
```json
  {
    "name": "My Firmware",
    "version": "1.0.0",
    "builds": [
      {
        "chipFamily": "ESP32-S3",
        "flashSizeMB": 16,
        "psramSizeMB": 8,
        "parts": [{ "path": "s3-16mb-8psram.bin", "offset": 0 }]
      },
      {
        "chipFamily": "ESP32-S3",
        "flashSizeMB": 4,
        "parts": [{ "path": "s3-4mb.bin", "offset": 0 }]
      },
      {
        "chipFamily": "ESP32-S3",
        "parts": [{ "path": "s3-generic.bin", "offset": 0 }]
      }
    ]
  }
```
  A device with an ESP32-S3, 16 MB flash, and 8 MB PSRAM gets the first build. A 4 MB device gets the second. Any other ESP32-S3 falls back to the third.

