### PR TITLE
Add Firefox to the list of supported WebSerial browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
       >
         <i slot="unsupported">
           The demo is not available because your browser does not support Web
-          Serial. Open this page in Google Chrome or Microsoft Edge instead<span
+          Serial. Open this page in Mozilla Firefox, Google Chrome or Microsoft Edge instead<span
             class="not-supported-i hidden"
           >
             (but not on your iOS device)</span
@@ -336,7 +336,7 @@
         firmware variant from the manifest.
       </p>
       <p>
-        Web Serial is available in Google Chrome and Microsoft Edge
+        Web Serial is available in Mozilla Firefox, Google Chrome and Microsoft Edge
         browsers<span class="not-supported-i hidden">
           (but not on your iOS device)</span
         >. Android support should be possible but has not been implemented yet.

--- a/src/install-button.ts
+++ b/src/install-button.ts
@@ -79,7 +79,7 @@ export class InstallButton extends HTMLElement {
       this.toggleAttribute("install-unsupported", true);
       this.renderRoot.innerHTML = !InstallButton.isAllowed
         ? "<slot name='not-allowed'>You can only install ESP devices on HTTPS websites or on the localhost.</slot>"
-        : "<slot name='unsupported'>Your browser does not support installing things on ESP devices. Use Google Chrome or Microsoft Edge.</slot>";
+        : "<slot name='unsupported'>Your browser does not support installing things on ESP devices. Use Mozilla Firefox, Google Chrome or Microsoft Edge.</slot>";
       return;
     }
 


### PR DESCRIPTION
Firefox now supports the Web Serial API. Promote it as the first browser mentioned in all three locations: the install button fallback message, the demo unsupported slot, and the documentation paragraph.

https://claude.ai/code/session_01Ntgqjoch3HySGe85uyUSoi