### PR TITLE
Show a message when Improv reports the stopped state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "esp-web-tools",
-  "version": "10.1.1",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esp-web-tools",
-      "version": "10.1.1",
+      "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/web": "^2.2.0",
         "esptool-js": "^0.5.7",
-        "improv-wifi-serial-sdk": "^2.5.0",
+        "improv-wifi-serial-sdk": "github:improv-wifi/sdk-serial-js#2.5.1",
         "lit": "^3.2.1",
         "pako": "^2.1.0",
         "tslib": "^2.8.1"
@@ -4032,8 +4032,8 @@
     },
     "node_modules/improv-wifi-serial-sdk": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.5.0.tgz",
-      "integrity": "sha512-aX8rHil24CD1avnB7Tzw5p/xnG7D8LJBDLT9pkCqPLxQQNp1F+EtZo+3wI6loaZUPp6IkMxM/1oRflvLM1aMUg==",
+      "resolved": "git+ssh://git@github.com/improv-wifi/sdk-serial-js.git#358aba0e9ad66a0b2f924091a846364f53ad4f20",
+      "license": "Apache-2.0",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
         "@material/mwc-circular-progress": "^0.27.0",
@@ -8102,9 +8102,8 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.5.0.tgz",
-      "integrity": "sha512-aX8rHil24CD1avnB7Tzw5p/xnG7D8LJBDLT9pkCqPLxQQNp1F+EtZo+3wI6loaZUPp6IkMxM/1oRflvLM1aMUg==",
+      "version": "git+ssh://git@github.com/improv-wifi/sdk-serial-js.git#358aba0e9ad66a0b2f924091a846364f53ad4f20",
+      "from": "improv-wifi-serial-sdk@github:improv-wifi/sdk-serial-js#2.5.1",
       "requires": {
         "@material/mwc-button": "^0.27.0",
         "@material/mwc-circular-progress": "^0.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@material/web": "^2.2.0",
         "esptool-js": "^0.5.7",
-        "improv-wifi-serial-sdk": "github:improv-wifi/sdk-serial-js#2.5.1",
+        "improv-wifi-serial-sdk": "2.5.1",
         "lit": "^3.2.1",
         "pako": "^2.1.0",
         "tslib": "^2.8.1"
@@ -4031,8 +4031,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.5.0",
-      "resolved": "git+ssh://git@github.com/improv-wifi/sdk-serial-js.git#358aba0e9ad66a0b2f924091a846364f53ad4f20",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.5.1.tgz",
+      "integrity": "sha512-tHdqg2UxWCAQuJSsy7IKB7tPFKra0bfJWQLb7YthPH/z3/bf08y4in+NkMpQ9ppT3XZe6EiHeGMRUhXpfZ8OYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
@@ -8102,8 +8103,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "git+ssh://git@github.com/improv-wifi/sdk-serial-js.git#358aba0e9ad66a0b2f924091a846364f53ad4f20",
-      "from": "improv-wifi-serial-sdk@github:improv-wifi/sdk-serial-js#2.5.1",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.5.1.tgz",
+      "integrity": "sha512-tHdqg2UxWCAQuJSsy7IKB7tPFKra0bfJWQLb7YthPH/z3/bf08y4in+NkMpQ9ppT3XZe6EiHeGMRUhXpfZ8OYw==",
       "requires": {
         "@material/mwc-button": "^0.27.0",
         "@material/mwc-circular-progress": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@material/web": "^2.2.0",
     "esptool-js": "^0.5.7",
-    "improv-wifi-serial-sdk": "^2.5.0",
+    "improv-wifi-serial-sdk": "github:improv-wifi/sdk-serial-js#2.5.1",
     "lit": "^3.2.1",
     "pako": "^2.1.0",
     "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@material/web": "^2.2.0",
     "esptool-js": "^0.5.7",
-    "improv-wifi-serial-sdk": "github:improv-wifi/sdk-serial-js#2.5.1",
+    "improv-wifi-serial-sdk": "2.5.1",
     "lit": "^3.2.1",
     "pako": "^2.1.0",
     "tslib": "^2.8.1"

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -253,9 +253,9 @@ export class EwtInstallDialog extends LitElement {
           >
             ${listItemWifi}
             <div slot="headline">
-              ${this._client!.state === ImprovSerialCurrentState.READY
-                ? "Connect to Wi-Fi"
-                : "Change Wi-Fi"}
+              ${this._client!.state === ImprovSerialCurrentState.PROVISIONED
+                ? "Change Wi-Fi"
+                : "Connect to Wi-Fi"}
             </div>
           </ew-list-item>
           <ew-list-item
@@ -359,7 +359,28 @@ export class EwtInstallDialog extends LitElement {
       ];
     }
 
-    if (
+    if (this._client!.state === ImprovSerialCurrentState.STOPPED) {
+      heading = undefined;
+      content = html`
+        <div slot="content">
+          <ewt-page-message
+            .icon=${ERROR_ICON}
+            .label=${html`The connected device has Wi-Fi turned off, so it
+              can't be configured right now.<br />Enable the device's Wi-Fi,
+              then try again.`}
+          ></ewt-page-message>
+        </div>
+        <div slot="actions">
+          <ew-text-button
+            @click=${() => {
+              this._state = "DASHBOARD";
+            }}
+          >
+            Back
+          </ew-text-button>
+        </div>
+      `;
+    } else if (
       !this._provisionForce &&
       this._client!.state === ImprovSerialCurrentState.PROVISIONED
     ) {
@@ -755,9 +776,13 @@ export class EwtInstallDialog extends LitElement {
     if (this._state !== "ERROR") {
       this._error = undefined;
     }
-    // Scan for SSIDs on provision
+    // Scan for SSIDs on provision. Skip when Improv is stopped: provisioning is
+    // unavailable, so a scan would only return an empty list and retry, and the
+    // "scanning" spinner would hide the stopped message.
     if (this._state === "PROVISION") {
-      this._updateSsids();
+      if (this._client?.state !== ImprovSerialCurrentState.STOPPED) {
+        this._updateSsids();
+      }
     } else {
       // Reset this value if we leave provisioning.
       this._provisionForce = false;

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -365,9 +365,9 @@ export class EwtInstallDialog extends LitElement {
         <div slot="content">
           <ewt-page-message
             .icon=${ERROR_ICON}
-            .label=${html`The connected device has Wi-Fi turned off, so it
-              can't be configured right now.<br />Enable the device's Wi-Fi,
-              then try again.`}
+            .label=${html`The connected device has Wi-Fi turned off, so it can't
+              be configured right now.<br />Enable the device's Wi-Fi, then try
+              again.`}
           ></ewt-page-message>
         </div>
         <div slot="actions">


### PR DESCRIPTION
## What

Surface a clear message when a connected device reports the Improv **stopped**
current state, instead of leading the user through a Wi-Fi provisioning form
that can't succeed:

<img src="https://github.com/user-attachments/assets/4c0d2c0a-7ae0-4643-9690-69e0a8fe86f7">

A device reports `STOPPED` when provisioning is currently unavailable — most
commonly because its Wi-Fi is disabled while it's running on Ethernet. Before
this change, esp-web-tools didn't recognize the state: it showed the credential
form, and submitting it would time out.

## Changes (`src/install-dialog.ts`)

- **Stopped-state message** in the provision view:
  > The connected device has Wi-Fi turned off, so it can't be configured right now.
  > Enable the device's Wi-Fi, then try again.
- **Skip the SSID scan when stopped** — otherwise `_updateSsids()` retries an
  empty network list and the "Scanning for networks" spinner hides the message.
- **Dashboard label** now reads "Connect to Wi-Fi" for any non-`PROVISIONED`
  state (a stopped device is not provisioned, so "Change Wi-Fi" was misleading).

## Dependency / blocking

> [!IMPORTANT]
> Depends on **improv-wifi/sdk-serial-js#138**, which adds `STOPPED` to
> `ImprovSerialCurrentState`. `improv-wifi-serial-sdk` is currently pinned to
> `github:improv-wifi/sdk-serial-js#2.5.1` (the GitHub release tag) because the
> npm publish for 2.5.1 [failed](https://github.com/improv-wifi/sdk-serial-js/actions/runs/27377994832)
> — the workflow published as `2.5.0` instead of `2.5.1`. A fix is tracked in
> **improv-wifi/sdk-serial-js#139**. Once that merges and 2.5.1 is re-released to
> npm, the reference here should be updated from the GitHub ref to the npm version
> and CI will pass.

## Testing

Verified end-to-end against an ESP32-S3 running ESPHome firmware that reports
`STOPPED` over Improv serial when Wi-Fi is disabled (device on Ethernet):
detection succeeds, the dashboard offers "Connect to Wi-Fi", and selecting it
shows the message above with no scan/retry loop. Normal (Wi-Fi-enabled)
provisioning is unaffected.

## See also

- esphome/esphome#16904