### PR TITLE
Fix relative firmware paths for blob: and data: URL manifests

### DIFF
--- a/src/flash.ts
+++ b/src/flash.ts
@@ -98,7 +98,13 @@ export const flash = async (
     details: { done: false },
   });
 
-  const manifestURL = new URL(manifestPath, location.toString()).toString();
+  // blob: and data: URLs (e.g. dynamically generated manifests via
+  // URL.createObjectURL) have an opaque path and can't be used as a base to
+  // resolve relative part paths, so fall back to the document location.
+  const manifestURL =
+    manifestPath.startsWith("blob:") || manifestPath.startsWith("data:")
+      ? location.toString()
+      : new URL(manifestPath, location.toString()).toString();
   const filePromises = build.parts.map(async (part) => {
     const url = new URL(part.path, manifestURL).toString();
     const resp = await fetch(url);

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -98,9 +98,6 @@ export const flash = async (
     details: { done: false },
   });
 
-  // blob: and data: URLs (e.g. dynamically generated manifests via
-  // URL.createObjectURL) have an opaque path and can't be used as a base to
-  // resolve relative part paths, so fall back to the document location.
   const manifestURL =
     manifestPath.startsWith("blob:") || manifestPath.startsWith("data:")
       ? location.toString()


### PR DESCRIPTION
Fixes #707

## Problem

The [dynamic manifest example in the docs](https://esphome.github.io/esp-web-tools/) generates the manifest with `URL.createObjectURL(blob)`, which produces a `blob:` URL. When installing, this fails with `Failed to construct 'URL': Invalid URL` — but only if a static manifest wasn't loaded first.

The root cause is in `flash.ts`, where relative firmware part paths are resolved against the manifest URL:

```js
const manifestURL = new URL(manifestPath, location.toString()).toString();
const url = new URL(part.path, manifestURL).toString(); // throws for blob:/data:
```

`blob:` (and `data:`) URLs have an **opaque path**, so they can't serve as a base for resolving a relative reference. Fetching the manifest itself works (fetch accepts blob URLs), which is why only the firmware parts break — and why loading a static manifest first "fixes" it: the parts then resolve against a real, document-relative base.

## Fix

When the manifest is a `blob:` or `data:` URL, resolve relative part paths against the document `location` instead of the unusable manifest URL. This matches how the documented dynamic-manifest example constructs its paths (relative to the page) and needs no new public API. Manifests referenced by a normal URL are unaffected.

## Testing

Verified the production build passes (`script/build`). I was not able to exercise a real flash end-to-end (requires WebSerial + a physical device), so this is verified by the build plus the URL-resolution behavior:

```
new URL("firmware/bootloader.bin", "blob:https://example.com/uuid")
// → throws "Invalid URL" (before)
// → resolved against location (after)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYj6zz8418zmvGsuCx3FFW)_