### PR TITLE
Bump CI Node version from 16 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: script/build
       - run: npm exec -- prettier --check src


### PR DESCRIPTION
Node 16 has been end-of-life since September 2023. This bumps the CI build job to Node 22 LTS.

It also unblocks #688 (`@rollup/plugin-terser` 1.0.0), which requires Node >= 20.

Node is only used for the build toolchain here; it does not affect the browser bundle that ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhC66FxoReu6294p67wyXL