### PR TITLE
Bump publish workflow Node version from 20 to 22

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install jq
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - name: Update npm to latest
         run: npm install -g npm@latest


### PR DESCRIPTION
Aligns the npm publish workflow with CI, which moved to Node 22 in #709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhC66FxoReu6294p67wyXL