### PR TITLE
Add serialType field to auto-select CDC vs UART firmware variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Allow flashing ESPHome or other ESP-based firmwares via the browser. Will automa
 
 Example manifest:
 
+The optional `serialType` field (`"cdc"` or `"uart"`) lets you ship separate firmware variants for chips that support both native USB CDC (built-in USB) and external USB-to-UART bridges. The correct variant is selected automatically based on the detected connection. Builds without a `serialType` are used as a fallback for any connection type.
+
 ```json
 {
   "name": "ESPHome",
@@ -46,11 +48,22 @@ Example manifest:
     },
     {
       "chipFamily": "ESP32-S3",
+      "serialType": "uart",
       "parts": [
         { "path": "bootloader_dout_40m.bin", "offset": 4096 },
         { "path": "partitions.bin", "offset": 32768 },
         { "path": "boot_app0.bin", "offset": 57344 },
         { "path": "esp32-s3.bin", "offset": 65536 }
+      ]
+    },
+    {
+      "chipFamily": "ESP32-S3",
+      "serialType": "cdc",
+      "parts": [
+        { "path": "bootloader_dout_40m.bin", "offset": 4096 },
+        { "path": "partitions.bin", "offset": 32768 },
+        { "path": "boot_app0.bin", "offset": 57344 },
+        { "path": "esp32-s3-cdc.bin", "offset": 65536 }
       ]
     },
     {

--- a/src/const.ts
+++ b/src/const.ts
@@ -21,6 +21,16 @@ export interface Build {
     path: string;
     offset: number;
   }[];
+  /**
+   * Optional serial transport type for this build variant.
+   * - `"cdc"`: Native USB CDC (e.g. ESP32-S2/S3/C3 built-in USB)
+   * - `"uart"`: External USB-to-UART bridge (e.g. CP2102, CH340)
+   * - absent: No transport preference; matches any connection as a fallback.
+   *
+   * Build selection tries an exact `serialType` match first, then falls back to a build
+   * with no `serialType`. If neither is found, installation is refused.
+   */
+  serialType?: "cdc" | "uart";
 }
 
 export interface Manifest {

--- a/src/const.ts
+++ b/src/const.ts
@@ -21,15 +21,6 @@ export interface Build {
     path: string;
     offset: number;
   }[];
-  /**
-   * Optional serial transport type for this build variant.
-   * - `"cdc"`: Native USB CDC (e.g. ESP32-S2/S3/C3 built-in USB)
-   * - `"uart"`: External USB-to-UART bridge (e.g. CP2102, CH340)
-   * - absent: No transport preference; matches any connection as a fallback.
-   *
-   * Build selection tries an exact `serialType` match first, then falls back to a build
-   * with no `serialType`. If neither is found, installation is refused.
-   */
   serialType?: "cdc" | "uart";
 }
 

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -39,9 +39,6 @@ export const flash = async (
 
   const transport = new Transport(port);
 
-  // Detect native USB CDC by checking Espressif's USB vendor ID (0x303a) and
-  // known CDC product IDs for chips with built-in USB (ESP32-S2, S3, C3, etc.).
-  // Devices connected via an external USB-to-UART bridge will not match.
   const portInfo = port.getInfo();
   const isCdcUsbPort =
     portInfo &&
@@ -90,10 +87,6 @@ export const flash = async (
     details: { done: true },
   });
 
-  // Select the build for this chip, preferring an exact serialType match for the
-  // detected connection (CDC for native USB, UART otherwise), then falling back to
-  // a build with no serialType specified. If neither is found, the "not supported"
-  // error fires below.
   const detectedSerialType = isCdcUsbPort ? "cdc" : "uart";
   build =
     manifest.builds.find(

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -38,6 +38,17 @@ export const flash = async (
     });
 
   const transport = new Transport(port);
+
+  // Detect native USB CDC by checking Espressif's USB vendor ID (0x303a) and
+  // known CDC product IDs for chips with built-in USB (ESP32-S2, S3, C3, etc.).
+  // Devices connected via an external USB-to-UART bridge will not match.
+  const portInfo = port.getInfo();
+  const isCdcUsbPort =
+    portInfo &&
+    portInfo.usbVendorId === 0x303a &&
+    portInfo.usbProductId !== undefined &&
+    [0x1001, 0x1002, 0x1003, 0x0002, 0x0003].includes(portInfo.usbProductId);
+
   const esploader = new ESPLoader({
     transport,
     baudrate: 115200,
@@ -79,7 +90,14 @@ export const flash = async (
     details: { done: true },
   });
 
-  build = manifest.builds.find((b) => b.chipFamily === chipFamily);
+  // Select the build for this chip, preferring an exact serialType match for the
+  // detected connection (CDC for native USB, UART otherwise), then falling back to
+  // a build with no serialType specified. If neither is found, the "not supported"
+  // error fires below.
+  const detectedSerialType = isCdcUsbPort ? "cdc" : "uart";
+  build =
+    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType) ||
+    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === undefined);
 
   if (!build) {
     fireStateEvent({

--- a/src/flash.ts
+++ b/src/flash.ts
@@ -96,8 +96,12 @@ export const flash = async (
   // error fires below.
   const detectedSerialType = isCdcUsbPort ? "cdc" : "uart";
   build =
-    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType) ||
-    manifest.builds.find((b) => b.chipFamily === chipFamily && b.serialType === undefined);
+    manifest.builds.find(
+      (b) => b.chipFamily === chipFamily && b.serialType === detectedSerialType,
+    ) ||
+    manifest.builds.find(
+      (b) => b.chipFamily === chipFamily && b.serialType === undefined,
+    );
 
   if (!build) {
     fireStateEvent({


### PR DESCRIPTION
Supersedes #685 — same change by @DTTerastar (commits keep his authorship), rebased onto `main` and with the inline comments stripped.

The ESPresense fork is organization-owned, so "allow edits by maintainers" does not grant push access and the rebase could not be pushed to the original PR branch.

Adds an optional `serialType` field (`"cdc"` | `"uart"`) to manifest builds so a project can ship separate firmware variants for chips that expose both native USB CDC and an external USB-to-UART bridge. Detection is based on the Espressif USB vendor ID plus known CDC product IDs; build selection prefers an exact `serialType` match and falls back to a build with no `serialType`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhC66FxoReu6294p67wyXL