### PR TITLE
Fix Wi-Fi picker: scan race, default selection, and signal colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@material/web": "^2.2.0",
         "esptool-js": "^0.6.0",
-        "improv-wifi-serial-sdk": "2.7.2",
+        "improv-wifi-serial-sdk": "2.8.0",
         "lit": "^3.2.1",
         "pako": "^2.1.0",
         "tslib": "^2.8.1"
@@ -2900,9 +2900,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.7.2.tgz",
-      "integrity": "sha512-N46iTFx8s1aU3mps56SbMj1eMUXeopnKTZIUrm5kL8WchIVenXwty5uKsuX/DKbZoomIGBvxWPhDF7UXh5XbAA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
+      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/web": "^2.4.1",
@@ -5777,9 +5777,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.7.2.tgz",
-      "integrity": "sha512-N46iTFx8s1aU3mps56SbMj1eMUXeopnKTZIUrm5kL8WchIVenXwty5uKsuX/DKbZoomIGBvxWPhDF7UXh5XbAA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
+      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
       "requires": {
         "@material/web": "^2.4.1",
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@material/web": "^2.2.0",
     "esptool-js": "^0.6.0",
-    "improv-wifi-serial-sdk": "2.7.2",
+    "improv-wifi-serial-sdk": "2.8.0",
     "lit": "^3.2.1",
     "pako": "^2.1.0",
     "tslib": "^2.8.1"

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -1208,11 +1208,9 @@ export class EwtInstallDialog extends LitElement {
         font-size: 12px;
       }
       .signal-excellent,
+      .signal-good,
       .lock-secured {
         color: #34a853;
-      }
-      .signal-good {
-        color: #4285f4;
       }
       .signal-fair {
         color: #fbbc04;


### PR DESCRIPTION
Addresses the Wi-Fi picker feedback in #712 ([comment](https://github.com/esphome/esp-web-tools/pull/712#issuecomment-4965408246)).

## What changed

**Bump `improv-wifi-serial-sdk` to 2.8.0.** The SDK now serializes Improv RPC commands (improv-wifi/sdk-serial-js#160), which fixes two of the reported picker bugs:

- **`Only 1 RPC command that requires feedback can be active`** when re-opening the Wi-Fi form is gone — commands are serialized instead of throwing when two overlap.
- **Default selection no longer drops to "Join other".** That was a symptom of the same race (a failed scan reported "can't scan", forcing "Join other"); with scans serialized the fresh scan returns networks and the picker preselects the strongest again.

**Drop the blue signal tier.** The "good" tier now shares green, so the picker uses only the three traffic-light colors (green / amber / red). The blue tier read as a separate, unclear state next to green.

Sorting by signal strength was intentionally left out, per discussion (no OS orders networks that way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CphD5A2hWy7Fw35BFRUcx