### PR TITLE
Bump lite-youtube from 1.4.0 to 1.9.0 on the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
     </style>
     <script
       type="module"
-      src="https://unpkg.com/@justinribeiro/lite-youtube@1.4.0/lite-youtube.js"
+      src="https://unpkg.com/@justinribeiro/lite-youtube@1.9.0/lite-youtube.js"
     ></script>
     <script module>
       import(


### PR DESCRIPTION
Updates the `@justinribeiro/lite-youtube` web component embedded on the landing page (`index.html`) from 1.4.0 to the latest 1.9.0.

Loaded via unpkg, single reference. All attributes the page uses — `videoid`, `videotitle`, `videoStartAt` — are still read by 1.9.0 (verified against the published 1.9.0 build), and it stays within the v1 major, so no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhC66FxoReu6294p67wyXL