### PR TITLE
Support multi-interface devices in the install dialog via Improv network state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@material/web": "^2.2.0",
         "esptool-js": "^0.6.0",
-        "improv-wifi-serial-sdk": "2.8.0",
+        "improv-wifi-serial-sdk": "2.8.1",
         "lit": "^3.2.1",
         "tslib": "^2.8.1"
       },
@@ -35,6 +35,7 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -102,6 +103,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -118,7 +120,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@babel/generator": {
       "version": "7.28.6",
@@ -421,6 +424,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
       "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.20.7",
@@ -1583,6 +1587,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1744,7 +1749,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2770,7 +2774,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -3014,7 +3017,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/core-js-compat": {
       "version": "3.45.0",
@@ -3192,6 +3196,7 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3230,9 +3235,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
-      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.1.tgz",
+      "integrity": "sha512-KU2D7bNbdUDUX0JK2nQGTGTuxJNH+loXyMR6DXBIzAh4/2dwiR2cxK0igvl+dLWjf4wRv43iUn/eQuUClw5V3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/web": "^2.4.1",
@@ -3369,6 +3374,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3746,7 +3752,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -4029,7 +4034,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc"
       },
@@ -4244,6 +4248,7 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -4295,6 +4300,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
           "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -4303,7 +4309,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -4528,6 +4535,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
       "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.20.7",
@@ -5273,6 +5281,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5388,8 +5397,7 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -5950,7 +5958,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
       "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -6117,7 +6124,8 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "core-js-compat": {
       "version": "3.45.0",
@@ -6249,7 +6257,8 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "get-stream": {
       "version": "6.0.1",
@@ -6273,9 +6282,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
-      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.1.tgz",
+      "integrity": "sha512-KU2D7bNbdUDUX0JK2nQGTGTuxJNH+loXyMR6DXBIzAh4/2dwiR2cxK0igvl+dLWjf4wRv43iUn/eQuUClw5V3g==",
       "requires": {
         "@material/web": "^2.4.1",
         "tslib": "^2.8.1"
@@ -6370,7 +6379,8 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "lit": {
       "version": "3.3.3",
@@ -6659,7 +6669,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.62.2",
         "@rollup/rollup-android-arm64": "4.62.2",
@@ -6857,7 +6866,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript/typescript-aix-ppc64": "7.0.2",
         "@typescript/typescript-darwin-arm64": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@material/web": "^2.2.0",
     "esptool-js": "^0.6.0",
-    "improv-wifi-serial-sdk": "2.8.0",
+    "improv-wifi-serial-sdk": "2.8.1",
     "lit": "^3.2.1",
     "tslib": "^2.8.1"
   }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -57,9 +57,10 @@ console.log(
 const ERROR_ICON = "⚠️";
 const OK_ICON = "🎉";
 
-// Bound on the network-state requests so a device that's unresponsive (e.g. rebooting to
-// switch network interface) or predates the command and stays silent can't hold up the
-// dialog. Other RPCs are bounded by the SDK's default timeout (30s).
+// Bound on the state/network-state requests so a device that's unresponsive (e.g. rebooting
+// to switch network interface) or predates the network-state command and stays silent can't
+// hold up the dialog — these run on every poll tick, so the bound also paces the poll loops.
+// Other RPCs are bounded by the SDK's default timeout (30s).
 const PROVISION_RPC_TIMEOUT = 5000;
 
 // How long to wait for the device to (dis)connect after sending Wi-Fi credentials. Kept a little
@@ -195,6 +196,9 @@ export class EwtInstallDialog extends LitElement {
         : this._renderDashboardNoImprov();
     } else if (this._state === "PROVISION") {
       [heading, content] = this._renderProvision();
+      // The busy screens have no Back button and their waits can be long, so
+      // keep closing available; the other provision screens have their own actions.
+      allowClosing = this._busy;
     } else if (this._state === "LOGS") {
       [heading, content] = this._renderLogs();
     }
@@ -251,21 +255,23 @@ export class EwtInstallDialog extends LitElement {
 
     const net = this._networkState;
     const state = this._client!.state;
-    // Wi-Fi provisioning is only offered when the device has Wi-Fi hardware and it isn't
-    // currently disabled (STOPPED, e.g. running on Ethernet). Legacy devices that don't
-    // report network state keep the prior always-shown behavior.
-    const showWifi =
-      net === undefined
-        ? true
-        : net.supportsWifi && state !== ImprovSerialCurrentState.STOPPED;
-    // The device may be online via a non-Wi-Fi interface (Ethernet); surface its reachable
-    // URL and the "online" affordances even when the Wi-Fi state machine isn't PROVISIONED.
+    // The device may be online via a non-Wi-Fi interface (Ethernet); surface the online
+    // affordances even when Wi-Fi isn't PROVISIONED. `net.online` is a snapshot from the
+    // last poll — a device that drops offline keeps its affordances (accepted, not re-polled).
     const deviceUrl = this._deviceUrl;
     const isOnline =
       state === ImprovSerialCurrentState.PROVISIONED || net?.online === true;
-    // Wi-Fi is unavailable but another interface (e.g. Ethernet) isn't online yet: offer
-    // the provisioning flow, which waits for that interface to come up instead of showing
-    // a Wi-Fi form (see _enterProvision).
+    // Offer Wi-Fi provisioning when the device has Wi-Fi hardware that isn't disabled
+    // (STOPPED, e.g. running on Ethernet). Legacy devices keep the prior always-shown item,
+    // as does a stranded device (Wi-Fi off, offline, no fallback) -> "enable Wi-Fi" guidance.
+    const showWifi =
+      net === undefined
+        ? true
+        : net.supportsWifi &&
+          (state !== ImprovSerialCurrentState.STOPPED ||
+            (!isOnline && !this._canComeOnlineWithoutWifi));
+    // Wi-Fi is unavailable but another interface (e.g. Ethernet) isn't online yet: offer the
+    // provisioning flow, which waits for that interface instead of showing a Wi-Fi form.
     const awaitNetwork =
       state === ImprovSerialCurrentState.STOPPED &&
       !isOnline &&
@@ -456,9 +462,8 @@ export class EwtInstallDialog extends LitElement {
       !this._connectedWithoutWifi
     ) {
       heading = undefined;
-      // Distinguish "Wi-Fi present but disabled" (tell the user to enable it) from "no Wi-Fi at
-      // all / couldn't come online" (don't mention Wi-Fi). Legacy devices (no network state) are
-      // assumed Wi-Fi-capable, preserving the prior message.
+      // Distinguish "Wi-Fi disabled" (tell the user to enable it) from "no Wi-Fi at all /
+      // couldn't come online". Legacy devices (no network state) keep the prior message.
       const wifiSupported = this._networkState?.supportsWifi ?? true;
       content = html`
         <div slot="content">
@@ -919,9 +924,6 @@ export class EwtInstallDialog extends LitElement {
     // Invalidate async continuations started for the previous page.
     this._provisionGeneration++;
     if (this._state === "PROVISION") {
-      // Re-query device/network state, then either let `_syncScanning` scan (Wi-Fi available)
-      // or wait for the device to come online via another interface (e.g. Ethernet). This also
-      // resets `_ssids` so the scan starts from scratch each time we enter provisioning.
       this._enterProvision();
     } else {
       // Reset these if we leave provisioning.
@@ -941,9 +943,8 @@ export class EwtInstallDialog extends LitElement {
     }
   }
 
-  // The device is online via a non-Wi-Fi interface (e.g. Ethernet) and Wi-Fi provisioning is
-  // unavailable (the Wi-Fi state machine reports STOPPED). In that case there's nothing to
-  // provision, so we show the "Device connected" screen instead of a Wi-Fi form / scan.
+  // Online via a non-Wi-Fi interface (e.g. Ethernet) while Wi-Fi provisioning is unavailable
+  // (STOPPED): nothing to provision, so the "Device connected" screen is shown.
   private get _connectedWithoutWifi(): boolean {
     return (
       this._client?.state === ImprovSerialCurrentState.STOPPED &&
@@ -961,115 +962,112 @@ export class EwtInstallDialog extends LitElement {
     );
   }
 
-  // A Wi-Fi-provisioned device reports its URL via nextUrl; a device online via another
-  // interface (e.g. Ethernet) has no nextUrl and instead reports reachable URLs in its
-  // network state.
+  // A Wi-Fi-provisioned device reports its URL via nextUrl; one online via another interface
+  // (e.g. Ethernet) reports reachable URLs in its network state instead.
   private get _deviceUrl(): string | undefined {
     return this._client?.nextUrl ?? this._networkState?.urls?.[0];
+  }
+
+  // Poll the device's network state every 2s (bounded by ONLINE_WAIT_MAX_TRIES) until
+  // `until` reports the wait is over, the page changes (any `_state` change or dialog
+  // close bumps `_provisionGeneration`), or the client is replaced.
+  private async _pollNetworkState(until: () => boolean) {
+    const gen = this._provisionGeneration;
+    const client = this._client;
+    for (let i = 0; i < ONLINE_WAIT_MAX_TRIES; i++) {
+      await sleep(2000);
+      if (gen !== this._provisionGeneration || this._client !== client) {
+        return;
+      }
+      await this._refreshDeviceState();
+      if (gen !== this._provisionGeneration || this._client !== client) {
+        return;
+      }
+      if (until()) {
+        return;
+      }
+    }
   }
 
   // Poll network state while the dashboard shows a device that could come online via a
   // non-Wi-Fi interface but isn't yet (e.g. just reset from the console), so it converges
   // to the online affordances. Ends on online, page/client change, or the wait bound.
   private async _watchNetworkStateUntilOnline() {
-    const gen = this._provisionGeneration;
-    const client = this._client;
-    for (let i = 0; i < ONLINE_WAIT_MAX_TRIES; i++) {
-      if (
-        this._state !== "DASHBOARD" ||
-        gen !== this._provisionGeneration ||
-        this._client !== client ||
-        !client ||
-        client.state !== ImprovSerialCurrentState.STOPPED ||
-        this._networkState?.online !== false ||
-        !this._canComeOnlineWithoutWifi
-      ) {
-        return;
-      }
-      await sleep(2000);
-      if (
-        this._state !== "DASHBOARD" ||
-        gen !== this._provisionGeneration ||
-        this._client !== client
-      ) {
-        return;
-      }
-      await this._refreshDeviceState();
+    const stopWatching = () =>
+      this._client?.state !== ImprovSerialCurrentState.STOPPED ||
+      this._networkState?.online !== false ||
+      !this._canComeOnlineWithoutWifi;
+    if (this._state !== "DASHBOARD" || stopWatching()) {
+      return;
     }
+    await this._pollNetworkState(stopWatching);
   }
 
   // Re-read the device's current state + network state. Bounded so an unresponsive device
   // (e.g. rebooting to switch network interface) can't hang us; errors are non-fatal and leave
   // the last-known values in place.
   private async _refreshDeviceState() {
+    const client = this._client!;
+    // A failed refresh must not leave its own error behind (the SDK stores a TIMEOUT on the
+    // client, and the provision form renders whatever the client holds): restore the
+    // pre-refresh error, e.g. a provision failure the form is about to display.
+    const error = client.error;
     try {
-      // The state request is bounded by the SDK's default RPC timeout (30s).
-      await this._client!.requestCurrentState();
-      this._networkState = await this._client!.requestNetworkState(
+      await client.requestCurrentState(PROVISION_RPC_TIMEOUT);
+      this._networkState = await client.requestNetworkState(
         PROVISION_RPC_TIMEOUT,
       );
     } catch (err) {
       this.logger.debug(`Could not refresh device state: ${err}`);
+      client.error = error;
     }
   }
 
   private async _enterProvision() {
-    // Reflect the loading state synchronously so any render during the async re-query below
-    // shows the scanning spinner (the `if (this._busy)` branch of _renderProvision) instead of
-    // falling through to the SSID form, which would dereference this._ssids before it's loaded.
+    // Set the loading state synchronously so any render during the re-query below shows
+    // the spinner instead of dereferencing `_ssids` before it's loaded.
     this._ssids = undefined;
     this._busy = true;
     this._connectingToNetwork = false;
 
-    // Bail after every await once the page moves on: a newer invocation (or no provisioning at
-    // all) owns the flags then. The same guard on the finally keeps a superseded invocation
-    // from stomping the newer one's spinner.
+    // Bail after every await once the page moves on: a newer invocation owns the flags then.
+    // The guard on the finally keeps a superseded invocation from stomping its spinner.
     const gen = this._provisionGeneration;
     try {
-      // The device's Wi-Fi availability can change after we first read it at connect time
-      // (e.g. a dual-interface device that detects an Ethernet link and disables Wi-Fi). Re-query
-      // before provisioning so we don't offer a Wi-Fi form / scan that can't succeed.
+      // Wi-Fi availability can change after connect time (e.g. a dual-interface device
+      // detects an Ethernet link and disables Wi-Fi); re-query so we don't offer a Wi-Fi
+      // form / scan that can't succeed.
       await this._refreshDeviceState();
       if (gen !== this._provisionGeneration) {
         return;
       }
 
-      // Wi-Fi provisioning is available unless the state machine reports STOPPED. Dropping
-      // `_busy` (in the finally) lets `_syncScanning` (driven from `updated()`) start the scan
-      // and show the form.
+      // Not STOPPED: Wi-Fi is provisionable. Dropping `_busy` (in the finally) lets
+      // `_syncScanning` start the scan and show the form.
       if (this._client?.state !== ImprovSerialCurrentState.STOPPED) {
         return;
       }
 
-      // Wi-Fi can't be provisioned here (no Wi-Fi, or Wi-Fi disabled because the device runs on
-      // another interface). If it's already online elsewhere, show the connected screen now.
+      // Wi-Fi can't be provisioned. If the device is already online elsewhere, show the
+      // connected screen now.
       if (this._connectedWithoutWifi) {
         return;
       }
 
-      // If the device can come online without Wi-Fi (e.g. Ethernet), wait for that — the analog
-      // of the Wi-Fi connect wait — so we land on the "Device connected" screen (with the Add to
-      // Home Assistant / Visit Device links) once the link is up.
       if (!this._canComeOnlineWithoutWifi) {
         // Wi-Fi is the only path and it's disabled -> "Wi-Fi off" message.
         return;
       }
 
       this._connectingToNetwork = true;
-      for (let i = 0; i < ONLINE_WAIT_MAX_TRIES; i++) {
-        await sleep(2000);
-        if (gen !== this._provisionGeneration) {
-          return;
-        }
-        await this._refreshDeviceState();
-        if (gen !== this._provisionGeneration) {
-          return;
-        }
-        if (this._connectedWithoutWifi) {
-          return; // -> connected screen
-        }
-      }
-      // Gave up waiting. _renderProvision shows a "not connected yet" message.
+      // Wait until the device comes online (-> connected screen) or leaves STOPPED (e.g. it
+      // re-enabled Wi-Fi -> the form shows right away instead of sitting out the wait).
+      await this._pollNetworkState(
+        () =>
+          this._client?.state !== ImprovSerialCurrentState.STOPPED ||
+          this._connectedWithoutWifi,
+      );
+      // `_renderProvision` picks the screen once `_busy` drops in the finally.
     } finally {
       if (gen === this._provisionGeneration) {
         this._connectingToNetwork = false;
@@ -1113,15 +1111,20 @@ export class EwtInstallDialog extends LitElement {
       if (this._ssids !== undefined || this._state !== "PROVISION") {
         return;
       }
-      // Nothing found. An empty scan is also what a device that rebooted onto another
-      // interface mid-flow answers (the reboot is invisible to us), so stop scanning and
-      // re-read the device state before showing a Wi-Fi form that may no longer succeed.
+      // A legacy device (no network state) can't have switched interfaces — show the form
+      // with manual entry right away instead of probing commands it doesn't support.
+      if (this._networkState === undefined) {
+        this._ssids = [];
+        this._selectedSsid = null;
+        return;
+      }
+      // An empty scan is also what a device that invisibly rebooted onto another interface
+      // answers, so stop scanning and re-read state before showing a doomed Wi-Fi form.
       const gen = this._provisionGeneration;
       await this._stopScanning();
       await this._refreshDeviceState();
-      // The awaits above run for seconds on an unresponsive device (RPC timeouts). If the user
-      // left provisioning — or left and re-entered — meanwhile, the new page owns scanning and
-      // `_ssids`; a late scan result may also have filled `_ssids` while we stopped.
+      // The awaits above can run for seconds. If the user left (or re-entered) provisioning
+      // meanwhile, the new page owns scanning; a late scan may also have filled `_ssids`.
       if (gen !== this._provisionGeneration || this._ssids !== undefined) {
         return;
       }
@@ -1276,18 +1279,27 @@ export class EwtInstallDialog extends LitElement {
       this._client = client;
       client.addEventListener("disconnect", this._handleDisconnect);
       // Optional command the SDK doesn't probe during initialize; do it ourselves. Legacy
-      // devices reject with UNKNOWN_RPC_COMMAND, leaving `_networkState` undefined so the
-      // UI falls back to Wi-Fi-state-only behavior.
+      // devices answer UNKNOWN_RPC_COMMAND, leaving `_networkState` undefined. A timeout is
+      // no answer — the device may just still be busy (e.g. post-install) — so retry those.
       this._networkState = undefined;
-      try {
-        this._networkState = await client.requestNetworkState(
-          PROVISION_RPC_TIMEOUT,
-        );
-      } catch (err) {
-        this.logger.debug(`Device does not report network state: ${err}`);
-        // Don't leave the probe's failure behind as the device error.
-        client.error = ImprovSerialErrorState.NO_ERROR;
+      for (let attempt = 0; ; attempt++) {
+        try {
+          this._networkState = await client.requestNetworkState(
+            PROVISION_RPC_TIMEOUT,
+          );
+          break;
+        } catch (err) {
+          if (
+            client.error !== ImprovSerialErrorState.TIMEOUT ||
+            attempt >= 2
+          ) {
+            this.logger.debug(`Device does not report network state: ${err}`);
+            break;
+          }
+        }
       }
+      // Don't leave the probe's failure behind as the device error.
+      client.error = ImprovSerialErrorState.NO_ERROR;
       // Needed here as well as in `willUpdate`: on first connect DASHBOARD is
       // the initial page (no state change), and on re-init after the logs page
       // the client didn't exist yet when `willUpdate` ran.
@@ -1377,17 +1389,11 @@ export class EwtInstallDialog extends LitElement {
       // would reject the next RPC (the resumed scan) instead of this one.
       await this._client!.provision(ssid, password, PROVISION_CONNECT_TIMEOUT);
     } catch (err: any) {
-      // A device that left Wi-Fi mode mid-flow rejects credentials immediately; re-read
-      // its state so the re-render shows the connected screen. Legacy devices skip the
-      // probe — it would overwrite the "Unable to connect" error the form shows.
+      // A device that left Wi-Fi mode mid-flow rejects credentials immediately; re-read its
+      // state so the re-render shows the connected screen. Legacy devices skip the probe; a
+      // failed probe keeps the provision error the form shows (see _refreshDeviceState).
       if (this._networkState) {
-        const provisionError = this._client!.error;
         await this._refreshDeviceState();
-        if (!this._connectedWithoutWifi) {
-          // Staying on the form after a genuine Wi-Fi failure: restore the
-          // provision error in case a refresh RPC (e.g. a timeout) replaced it.
-          this._client!.error = provisionError;
-        }
       }
       return;
     } finally {
@@ -1407,6 +1413,9 @@ export class EwtInstallDialog extends LitElement {
   }
 
   private async _handleClose() {
+    // Closing doesn't change `_state`, so bump the generation to stop any poll loop
+    // from issuing RPCs against the closed client.
+    this._provisionGeneration++;
     if (this._client) {
       await this._closeClientWithoutEvents(this._client);
     }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -31,7 +31,11 @@ import {
   networkWifiFull,
 } from "./components/svg";
 import { Logger, Manifest, FlashStateType, FlashState } from "./const.js";
-import { ImprovSerial, Ssid } from "improv-wifi-serial-sdk/dist/serial";
+import {
+  ImprovSerial,
+  NetworkState,
+  Ssid,
+} from "improv-wifi-serial-sdk/dist/serial";
 import {
   ImprovSerialCurrentState,
   ImprovSerialErrorState,
@@ -53,9 +57,9 @@ console.log(
 const ERROR_ICON = "⚠️";
 const OK_ICON = "🎉";
 
-// Bound RPCs issued while (re)entering provisioning so a device that's unresponsive (e.g.
-// rebooting to switch network interface) can't hang the dialog. On expiry we fall through to
-// the normal empty-scan handling (manual SSID entry) instead of waiting forever.
+// Bound on the network-state requests so a device that's unresponsive (e.g. rebooting to
+// switch network interface) or predates the command and stays silent can't hold up the
+// dialog. Other RPCs are bounded by the SDK's default timeout (30s).
 const PROVISION_RPC_TIMEOUT = 5000;
 
 // How long to wait for the device to (dis)connect after sending Wi-Fi credentials. Kept a little
@@ -109,6 +113,11 @@ export class EwtInstallDialog extends LitElement {
 
   // null = NOT_SUPPORTED
   @state() private _client?: ImprovSerial | null;
+
+  // Connectivity + interface inventory from the device's network state; undefined when the
+  // device predates the command. The SDK returns rather than stores it, so we keep it here —
+  // refreshed in _initialize and _refreshDeviceState, whose callers trigger the re-renders.
+  private _networkState?: NetworkState;
 
   @state() private _state:
     | "ERROR"
@@ -242,7 +251,7 @@ export class EwtInstallDialog extends LitElement {
     let content: TemplateResult;
     let allowClosing = true;
 
-    const net = this._client!.networkState;
+    const net = this._networkState;
     const state = this._client!.state;
     // Wi-Fi provisioning is only offered when the device has Wi-Fi hardware and it isn't
     // currently disabled (STOPPED, e.g. running on Ethernet). Legacy devices that don't
@@ -255,7 +264,7 @@ export class EwtInstallDialog extends LitElement {
     // URL and the "online" affordances even when the Wi-Fi state machine isn't PROVISIONED.
     const deviceUrl = this._deviceUrl;
     const isOnline =
-      state === ImprovSerialCurrentState.PROVISIONED || net?.isOnline === true;
+      state === ImprovSerialCurrentState.PROVISIONED || net?.online === true;
     // Wi-Fi is unavailable but the device isn't online yet over its other interface (e.g.
     // Ethernet cable unplugged): still offer the provisioning flow, which waits for that
     // interface to come up instead of showing a Wi-Fi form (see _enterProvision). Without
@@ -453,7 +462,7 @@ export class EwtInstallDialog extends LitElement {
       // Distinguish "Wi-Fi present but disabled" (tell the user to enable it) from "no Wi-Fi at
       // all / couldn't come online" (don't mention Wi-Fi). Legacy devices (no network state) are
       // assumed Wi-Fi-capable, preserving the prior message.
-      const wifiSupported = this._client!.networkState?.supportsWifi ?? true;
+      const wifiSupported = this._networkState?.supportsWifi ?? true;
       content = html`
         <div slot="content">
           <ewt-page-message
@@ -935,14 +944,14 @@ export class EwtInstallDialog extends LitElement {
   private get _connectedWithoutWifi(): boolean {
     return (
       this._client?.state === ImprovSerialCurrentState.STOPPED &&
-      this._client?.networkState?.isOnline === true
+      this._networkState?.online === true
     );
   }
 
   // The device has a network interface other than Wi-Fi (e.g. Ethernet), so it can come
   // online without Wi-Fi provisioning.
   private get _canComeOnlineWithoutWifi(): boolean {
-    const net = this._client?.networkState;
+    const net = this._networkState;
     return (
       net !== undefined &&
       (net.supportsEthernet || net.supportsThread || net.supportsModem)
@@ -953,7 +962,7 @@ export class EwtInstallDialog extends LitElement {
   // interface (e.g. Ethernet) has no nextUrl and instead reports reachable URLs in its
   // network state.
   private get _deviceUrl(): string | undefined {
-    return this._client?.nextUrl ?? this._client?.networkState?.urls?.[0];
+    return this._client?.nextUrl ?? this._networkState?.urls?.[0];
   }
 
   // Re-read the device's current state + network state. Bounded so an unresponsive device
@@ -961,8 +970,11 @@ export class EwtInstallDialog extends LitElement {
   // the last-known values in place.
   private async _refreshDeviceState() {
     try {
-      await this._client!.requestCurrentState(PROVISION_RPC_TIMEOUT);
-      await this._client!.requestNetworkState(PROVISION_RPC_TIMEOUT);
+      // The state request is bounded by the SDK's default RPC timeout (30s).
+      await this._client!.requestCurrentState();
+      this._networkState = await this._client!.requestNetworkState(
+        PROVISION_RPC_TIMEOUT,
+      );
     } catch (err) {
       this.logger.debug(`Could not refresh device state: ${err}`);
     }
@@ -1235,6 +1247,20 @@ export class EwtInstallDialog extends LitElement {
       this._info = await client.initialize(timeout);
       this._client = client;
       client.addEventListener("disconnect", this._handleDisconnect);
+      // The network-state command is optional and the SDK doesn't probe it during
+      // initialize; do it ourselves. Devices that predate it reject with
+      // UNKNOWN_RPC_COMMAND, leaving `_networkState` undefined so the UI falls back
+      // to Wi-Fi-state-only behavior.
+      this._networkState = undefined;
+      try {
+        this._networkState = await client.requestNetworkState(
+          PROVISION_RPC_TIMEOUT,
+        );
+      } catch (err) {
+        this.logger.debug(`Device does not report network state: ${err}`);
+        // Don't leave the probe's failure behind as the device error.
+        client.error = ImprovSerialErrorState.NO_ERROR;
+      }
     } catch (err: any) {
       // Clear old value
       this._info = undefined;
@@ -1328,7 +1354,7 @@ export class EwtInstallDialog extends LitElement {
       // can never succeed. Skip legacy devices (no network state): they can't
       // be online without Wi-Fi, and probing 0x07 would overwrite the
       // "Unable to connect" error the form is about to display.
-      if (this._client!.networkState) {
+      if (this._networkState) {
         const provisionError = this._client!.error;
         await this._refreshDeviceState();
         if (!this._connectedWithoutWifi) {

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -53,6 +53,21 @@ console.log(
 const ERROR_ICON = "⚠️";
 const OK_ICON = "🎉";
 
+// Bound RPCs issued while (re)entering provisioning so a device that's unresponsive (e.g.
+// rebooting to switch network interface) can't hang the dialog. On expiry we fall through to
+// the normal empty-scan handling (manual SSID entry) instead of waiting forever.
+const PROVISION_RPC_TIMEOUT = 5000;
+
+// How long to wait for the device to (dis)connect after sending Wi-Fi credentials. Kept a little
+// longer than the device's own connect timeout (improv_serial: 90s) so the device's success/error
+// reaches us before we give up — switching networks on an already-connected device can exceed 30s.
+const PROVISION_CONNECT_TIMEOUT = 95000;
+
+// When Wi-Fi isn't being provisioned but the device can come online via another interface
+// (e.g. Ethernet), poll its network state this many times (×2s) waiting for it to report online
+// before giving up. Covers Ethernet link-up and any interface-switch reboot.
+const ONLINE_WAIT_MAX_TRIES = 20;
+
 // A device that just booted can come back from its first scan with no networks
 // at all. Keep looking (the SDK scans every 3s, so this covers four scans)
 // before giving up and showing the form, or we'd tell the user we found nothing
@@ -113,6 +128,10 @@ export class EwtInstallDialog extends LitElement {
   @state() private _error?: string;
 
   @state() private _busy = false;
+
+  // True while waiting (spinner) for a non-Wi-Fi device to come online (e.g. Ethernet link up),
+  // so the progress label reads "Connecting to the network" rather than "Scanning for networks".
+  @state() private _connectingToNetwork = false;
 
   // undefined = not loaded
   // null = not available
@@ -216,6 +235,21 @@ export class EwtInstallDialog extends LitElement {
     let content: TemplateResult;
     let allowClosing = true;
 
+    const net = this._client!.networkState;
+    const state = this._client!.state;
+    // Wi-Fi provisioning is only offered when the device has Wi-Fi hardware and it isn't
+    // currently disabled (STOPPED, e.g. running on Ethernet). Legacy devices that don't
+    // report network state keep the prior always-shown behavior.
+    const showWifi =
+      net === undefined
+        ? true
+        : net.supportsWifi && state !== ImprovSerialCurrentState.STOPPED;
+    // The device may be online via a non-Wi-Fi interface (Ethernet); surface its reachable
+    // URL and the "online" affordances even when the Wi-Fi state machine isn't PROVISIONED.
+    const deviceUrl = this._client!.nextUrl ?? net?.urls?.[0];
+    const isOnline =
+      state === ImprovSerialCurrentState.PROVISIONED || net?.isOnline === true;
+
     content = html`
       <div slot="content">
         <ew-list>
@@ -249,20 +283,15 @@ export class EwtInstallDialog extends LitElement {
                 </ew-list-item>
               `
             : ""}
-          ${this._client!.nextUrl === undefined
+          ${deviceUrl === undefined
             ? ""
             : html`
-                <ew-list-item
-                  type="link"
-                  href=${this._client!.nextUrl}
-                  target="_blank"
-                >
+                <ew-list-item type="link" href=${deviceUrl} target="_blank">
                   ${listItemVisitDevice}
                   <div slot="headline">Visit Device</div>
                 </ew-list-item>
               `}
-          ${!this._manifest.home_assistant_domain ||
-          this._client!.state !== ImprovSerialCurrentState.PROVISIONED
+          ${!this._manifest.home_assistant_domain || !isOnline
             ? ""
             : html`
                 <ew-list-item
@@ -274,24 +303,30 @@ export class EwtInstallDialog extends LitElement {
                   <div slot="headline">Add to Home Assistant</div>
                 </ew-list-item>
               `}
-          <ew-list-item
-            type="button"
-            @click=${() => {
-              this._state = "PROVISION";
-              if (
-                this._client!.state === ImprovSerialCurrentState.PROVISIONED
-              ) {
-                this._provisionForce = true;
-              }
-            }}
-          >
-            ${listItemWifi}
-            <div slot="headline">
-              ${this._client!.state === ImprovSerialCurrentState.PROVISIONED
-                ? "Change Wi-Fi"
-                : "Connect to Wi-Fi"}
-            </div>
-          </ew-list-item>
+          ${!showWifi
+            ? ""
+            : html`
+                <ew-list-item
+                  type="button"
+                  @click=${() => {
+                    this._state = "PROVISION";
+                    if (
+                      this._client!.state ===
+                      ImprovSerialCurrentState.PROVISIONED
+                    ) {
+                      this._provisionForce = true;
+                    }
+                  }}
+                >
+                  ${listItemWifi}
+                  <div slot="headline">
+                    ${this._client!.state ===
+                    ImprovSerialCurrentState.PROVISIONED
+                      ? "Change Wi-Fi"
+                      : "Connect to Wi-Fi"}
+                  </div>
+                </ew-list-item>
+              `}
           <ew-list-item
             type="button"
             @click=${async () => {
@@ -379,22 +414,39 @@ export class EwtInstallDialog extends LitElement {
   }
 
   _renderProvision(): [string | undefined, TemplateResult] {
-    let heading: string | undefined = "Configure Wi-Fi";
+    let heading: string | undefined = "Configure network";
     let content: TemplateResult;
 
     if (this._busy) {
-      return [heading, this._renderProgress("Trying to connect")];
+      return [
+        heading,
+        this._renderProgress(
+          this._connectingToNetwork
+            ? "Connecting to the network"
+            : "Trying to connect",
+        ),
+      ];
     }
 
-    if (this._client!.state === ImprovSerialCurrentState.STOPPED) {
+    if (
+      this._client!.state === ImprovSerialCurrentState.STOPPED &&
+      !this._connectedWithoutWifi
+    ) {
       heading = undefined;
+      // Distinguish "Wi-Fi present but disabled" (tell the user to enable it) from "no Wi-Fi at
+      // all / couldn't come online" (don't mention Wi-Fi). Legacy devices (no network state) are
+      // assumed Wi-Fi-capable, preserving the prior message.
+      const wifiSupported = this._client!.networkState?.supportsWifi ?? true;
       content = html`
         <div slot="content">
           <ewt-page-message
             .icon=${ERROR_ICON}
-            .label=${html`The connected device has Wi-Fi turned off, so it can't
-              be configured right now.<br />Enable the device's Wi-Fi, then try
-              again.`}
+            .label=${wifiSupported
+              ? html`The connected device has Wi-Fi turned off, so it can't be
+                  configured right now.<br />Enable the device's Wi-Fi, then try
+                  again.`
+              : html`The device hasn't connected to the network yet.<br />Check
+                  its network connection, then try again.`}
           ></ewt-page-message>
         </div>
         <div slot="actions">
@@ -408,14 +460,18 @@ export class EwtInstallDialog extends LitElement {
         </div>
       `;
     } else if (
-      !this._provisionForce &&
-      this._client!.state === ImprovSerialCurrentState.PROVISIONED
+      this._connectedWithoutWifi ||
+      (!this._provisionForce &&
+        this._client!.state === ImprovSerialCurrentState.PROVISIONED)
     ) {
       heading = undefined;
+      // A device online via a non-Wi-Fi interface (e.g. Ethernet) has no Wi-Fi nextUrl; fall
+      // back to the reachable URL reported in its network state.
+      const deviceUrl =
+        this._client!.nextUrl ?? this._client!.networkState?.urls?.[0];
       const showSetupLinks =
         !this._wasProvisioned &&
-        (this._client!.nextUrl !== undefined ||
-          "home_assistant_domain" in this._manifest);
+        (deviceUrl !== undefined || "home_assistant_domain" in this._manifest);
       content = html`
         <div slot="content">
           <ewt-page-message
@@ -425,12 +481,12 @@ export class EwtInstallDialog extends LitElement {
           ${showSetupLinks
             ? html`
                 <ew-list>
-                  ${this._client!.nextUrl === undefined
+                  ${deviceUrl === undefined
                     ? ""
                     : html`
                         <ew-list-item
                           type="link"
-                          href=${this._client!.nextUrl}
+                          href=${deviceUrl}
                           target="_blank"
                           @click=${() => {
                             this._state = "DASHBOARD";
@@ -723,13 +779,12 @@ export class EwtInstallDialog extends LitElement {
           ${this._installState.chipFamily === "ESP8266"
             ? "a minute"
             : "2 minutes"}.<br />
-          Keep this page visible to prevent slow down
+          Keep this page visible for fastest installation.
         `,
         percentage,
       );
     } else if (this._installState.state === FlashStateType.FINISHED) {
       heading = undefined;
-      const supportsImprov = this._client !== null;
       content = html`
         <ewt-page-message
           slot="content"
@@ -739,9 +794,25 @@ export class EwtInstallDialog extends LitElement {
 
         <div slot="actions">
           <ew-text-button
-            @click=${() => {
+            @click=${async () => {
+              // Improv detection runs once right after flashing; a slow-booting device can miss
+              // that window and get marked "not detected" (_client === null). Retry here so
+              // clicking Next gives it another chance before we decide where to go.
+              if (this._client === null) {
+                this._client = undefined; // shows the "Connecting" progress
+                this._state = "DASHBOARD"; // leave INSTALL so progress (not this screen) renders
+                await this._initialize(true);
+                // Cast: TS narrows _state to "DASHBOARD" from the assignment above and can't see
+                // that _initialize may set it to "ERROR" across the await.
+                if ((this._state as string) === "ERROR") {
+                  return; // _initialize surfaced a fatal error; don't override it
+                }
+              }
+              // After an erase install, enter provisioning so the device can be brought online:
+              // Wi-Fi devices get the setup form, while non-Wi-Fi devices (e.g. Ethernet) wait for
+              // the link to come up and then show the connected screen (see _enterProvision).
               this._state =
-                supportsImprov && this._installErase
+                this._client !== null && this._installErase
                   ? "PROVISION"
                   : "DASHBOARD";
             }}
@@ -825,19 +896,106 @@ export class EwtInstallDialog extends LitElement {
     if (this._state !== "ERROR") {
       this._error = undefined;
     }
-    // Scan for networks from scratch every time we enter provisioning.
-    // `_syncScanning` picks it up from here.
     if (this._state === "PROVISION") {
-      this._ssids = undefined;
+      // Re-query device/network state, then either let `_syncScanning` scan (Wi-Fi available)
+      // or wait for the device to come online via another interface (e.g. Ethernet). This also
+      // resets `_ssids` so the scan starts from scratch each time we enter provisioning.
+      this._enterProvision();
     } else {
-      // Reset this value if we leave provisioning.
+      // Reset these if we leave provisioning.
       this._provisionForce = false;
+      this._connectingToNetwork = false;
     }
 
     if (this._state === "INSTALL") {
       this._installConfirmed = false;
       this._installState = undefined;
     }
+  }
+
+  // The device is online via a non-Wi-Fi interface (e.g. Ethernet) and Wi-Fi provisioning is
+  // unavailable (the Wi-Fi state machine reports STOPPED). In that case there's nothing to
+  // provision, so we show the "Device connected" screen instead of a Wi-Fi form / scan.
+  private get _connectedWithoutWifi(): boolean {
+    return (
+      this._client?.state === ImprovSerialCurrentState.STOPPED &&
+      this._client?.networkState?.isOnline === true
+    );
+  }
+
+  // Re-read the device's current state + network state. Bounded so an unresponsive device
+  // (e.g. rebooting to switch network interface) can't hang us; errors are non-fatal and leave
+  // the last-known values in place.
+  private async _refreshDeviceState() {
+    try {
+      await this._client!.requestCurrentState(PROVISION_RPC_TIMEOUT);
+      await this._client!.requestNetworkState(PROVISION_RPC_TIMEOUT);
+    } catch (err) {
+      this.logger.debug(`Could not refresh device state: ${err}`);
+    }
+  }
+
+  private async _enterProvision() {
+    // Reflect the loading state synchronously so any render during the async re-query below
+    // shows the scanning spinner (the `if (this._busy)` branch of _renderProvision) instead of
+    // falling through to the SSID form, which would dereference this._ssids before it's loaded.
+    this._ssids = undefined;
+    this._busy = true;
+
+    this._connectingToNetwork = false;
+
+    // The device's Wi-Fi availability can change after we first read it at connect time
+    // (e.g. a dual-interface device that detects an Ethernet link and disables Wi-Fi). Re-query
+    // before provisioning so we don't offer a Wi-Fi form / scan that can't succeed.
+    await this._refreshDeviceState();
+
+    // Wi-Fi provisioning is available unless the state machine reports STOPPED. If it is, drop
+    // `_busy` and let `_syncScanning` (driven from `updated()`) start the scan and show the form.
+    if (this._client?.state !== ImprovSerialCurrentState.STOPPED) {
+      this._busy = false;
+      return;
+    }
+
+    // Wi-Fi can't be provisioned here (no Wi-Fi, or Wi-Fi disabled because the device runs on
+    // another interface). If it's already online elsewhere, show the connected screen now.
+    if (this._connectedWithoutWifi) {
+      this._busy = false;
+      return;
+    }
+
+    // If the device can come online without Wi-Fi (e.g. Ethernet), wait for that — the analog of
+    // the Wi-Fi connect wait — so we land on the "Device connected" screen (with the Add to Home
+    // Assistant / Visit Device links) once the link is up.
+    const net = this._client?.networkState;
+    const canComeOnlineWithoutWifi =
+      net !== undefined &&
+      (net.supportsEthernet || net.supportsThread || net.supportsModem);
+    if (!canComeOnlineWithoutWifi) {
+      // Wi-Fi is the only path and it's disabled -> "Wi-Fi off" message.
+      this._busy = false;
+      return;
+    }
+
+    this._connectingToNetwork = true;
+    for (
+      let i = 0;
+      i < ONLINE_WAIT_MAX_TRIES && this._state === "PROVISION";
+      i++
+    ) {
+      await sleep(2000);
+      if (this._state !== "PROVISION") {
+        return; // user navigated away
+      }
+      await this._refreshDeviceState();
+      if (this._connectedWithoutWifi) {
+        this._connectingToNetwork = false;
+        this._busy = false; // -> connected screen
+        return;
+      }
+    }
+    // Gave up waiting; stop the spinner. _renderProvision shows a "not connected yet" message.
+    this._connectingToNetwork = false;
+    this._busy = false;
   }
 
   /**
@@ -1095,11 +1253,11 @@ export class EwtInstallDialog extends LitElement {
     // `_syncScanning` to stop, but the provision RPC needs it stopped *now*.
     await this._stopScanning();
     try {
-      // Devices try to connect for ~30s before reporting failure. Our timeout
-      // must comfortably exceed that: it's only a safety net, and if it fires
-      // first the device's late failure packet rejects the *next* RPC we send
-      // (the resumed network scan) instead of this one.
-      await this._client!.provision(ssid, password, 45000);
+      // Our timeout must comfortably exceed the device's own connect attempt (improv_serial waits
+      // up to ~90s, longer than the ~30s Wi-Fi case, since switching networks on an already-online
+      // device can be slow). It's only a safety net: if it fires first, the device's late failure
+      // packet rejects the *next* RPC we send (the resumed network scan) instead of this one.
+      await this._client!.provision(ssid, password, PROVISION_CONNECT_TIMEOUT);
     } catch (err: any) {
       return;
     } finally {

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -114,12 +114,9 @@ export class EwtInstallDialog extends LitElement {
   // null = NOT_SUPPORTED
   @state() private _client?: ImprovSerial | null;
 
-  // Connectivity + interface inventory from the device's network state; undefined when the
-  // device predates the command. The SDK returns rather than stores it, so we keep it here,
-  // refreshed in _initialize and _refreshDeviceState. Reactive because refreshes complete
-  // after the render that a new `_client` (or a page change) already triggered — the dashboard
-  // would otherwise keep showing the pre-probe snapshot (e.g. "Connect to Wi-Fi" on an
-  // Ethernet-connected device after returning from the logs page).
+  // Network state from the device; undefined when it predates the command. Reactive:
+  // refreshes complete after the render a new client already triggered, which would
+  // otherwise leave the dashboard on the pre-probe snapshot.
   @state() private _networkState?: NetworkState;
 
   @state() private _state:
@@ -146,10 +143,8 @@ export class EwtInstallDialog extends LitElement {
   @state() private _connectingToNetwork = false;
 
   // Monotonic id for the current page, bumped on every `_state` change. Async provisioning
-  // continuations (the `_enterProvision` wait loop, the scan-grace callback) capture it and
-  // bail once it moves on: `_state === "PROVISION"` alone can't tell a new provisioning
-  // session from the one they were started for, so without this a continuation that survives
-  // a quick leave-and-re-enter would keep mutating the new session's state.
+  // continuations capture it and bail once it moves on — `_state` alone can't tell a new
+  // provisioning session from the one they were started for.
   private _provisionGeneration = 0;
 
   // undefined = not loaded
@@ -268,10 +263,9 @@ export class EwtInstallDialog extends LitElement {
     const deviceUrl = this._deviceUrl;
     const isOnline =
       state === ImprovSerialCurrentState.PROVISIONED || net?.online === true;
-    // Wi-Fi is unavailable but the device isn't online yet over its other interface (e.g.
-    // Ethernet cable unplugged): still offer the provisioning flow, which waits for that
-    // interface to come up instead of showing a Wi-Fi form (see _enterProvision). Without
-    // this the dashboard would have no network affordance at all in that state.
+    // Wi-Fi is unavailable but another interface (e.g. Ethernet) isn't online yet: offer
+    // the provisioning flow, which waits for that interface to come up instead of showing
+    // a Wi-Fi form (see _enterProvision).
     const awaitNetwork =
       state === ImprovSerialCurrentState.STOPPED &&
       !isOnline &&
@@ -974,11 +968,9 @@ export class EwtInstallDialog extends LitElement {
     return this._client?.nextUrl ?? this._networkState?.urls?.[0];
   }
 
-  // While the dashboard shows a device that could come online via a non-Wi-Fi interface but
-  // isn't yet (e.g. it was just reset from the console and its Ethernet link is still coming
-  // up), poll its network state so the dashboard converges to the online affordances without
-  // user interaction. Ends when the device reports online, the page or client changes, or
-  // after the same bound as the provisioning wait.
+  // Poll network state while the dashboard shows a device that could come online via a
+  // non-Wi-Fi interface but isn't yet (e.g. just reset from the console), so it converges
+  // to the online affordances. Ends on online, page/client change, or the wait bound.
   private async _watchNetworkStateUntilOnline() {
     const gen = this._provisionGeneration;
     const client = this._client;
@@ -1121,13 +1113,9 @@ export class EwtInstallDialog extends LitElement {
       if (this._ssids !== undefined || this._state !== "PROVISION") {
         return;
       }
-      // Nothing found within the grace period. On a Wi-Fi-capable device an
-      // empty scan is suspicious: it is also what we see when the device
-      // rebooted onto another interface mid-flow (e.g. it detected an Ethernet
-      // link and disabled Wi-Fi) — the reboot is invisible to us, and the new
-      // boot still answers scans with empty lists. Re-read the device state
-      // before showing a Wi-Fi form that may no longer be able to succeed.
-      // Stop scanning first so the state RPCs don't overlap an in-flight scan.
+      // Nothing found. An empty scan is also what a device that rebooted onto another
+      // interface mid-flow answers (the reboot is invisible to us), so stop scanning and
+      // re-read the device state before showing a Wi-Fi form that may no longer succeed.
       const gen = this._provisionGeneration;
       await this._stopScanning();
       await this._refreshDeviceState();
@@ -1143,10 +1131,9 @@ export class EwtInstallDialog extends LitElement {
         this._ssids = [];
         this._selectedSsid = null;
       } else {
-        // The device left Wi-Fi provisioning mid-scan (e.g. it is now online
-        // via Ethernet). `state`/`networkState` aren't reactive properties, so
-        // re-render explicitly; `_renderProvision` picks the right screen and
-        // scanning stays stopped.
+        // The device left Wi-Fi provisioning mid-scan (e.g. now online via Ethernet).
+        // `state` isn't reactive, so re-render explicitly; `_renderProvision` picks the
+        // right screen and scanning stays stopped.
         this.requestUpdate();
       }
     }, SCAN_GRACE_PERIOD);
@@ -1288,10 +1275,9 @@ export class EwtInstallDialog extends LitElement {
       this._info = await client.initialize(timeout);
       this._client = client;
       client.addEventListener("disconnect", this._handleDisconnect);
-      // The network-state command is optional and the SDK doesn't probe it during
-      // initialize; do it ourselves. Devices that predate it reject with
-      // UNKNOWN_RPC_COMMAND, leaving `_networkState` undefined so the UI falls back
-      // to Wi-Fi-state-only behavior.
+      // Optional command the SDK doesn't probe during initialize; do it ourselves. Legacy
+      // devices reject with UNKNOWN_RPC_COMMAND, leaving `_networkState` undefined so the
+      // UI falls back to Wi-Fi-state-only behavior.
       this._networkState = undefined;
       try {
         this._networkState = await client.requestNetworkState(
@@ -1386,19 +1372,14 @@ export class EwtInstallDialog extends LitElement {
     // `_syncScanning` to stop, but the provision RPC needs it stopped *now*.
     await this._stopScanning();
     try {
-      // Our timeout must comfortably exceed the device's own connect attempt (improv_serial waits
-      // up to ~90s, longer than the ~30s Wi-Fi case, since switching networks on an already-online
-      // device can be slow). It's only a safety net: if it fires first, the device's late failure
-      // packet rejects the *next* RPC we send (the resumed network scan) instead of this one.
+      // Must comfortably exceed the device's own connect attempt (up to ~90s when switching
+      // networks on an already-online device); it's only a safety net, and firing first
+      // would reject the next RPC (the resumed scan) instead of this one.
       await this._client!.provision(ssid, password, PROVISION_CONNECT_TIMEOUT);
     } catch (err: any) {
-      // Provisioning failed. One cause: the device left Wi-Fi mode mid-flow
-      // (e.g. it detected an Ethernet link and rebooted with Wi-Fi disabled),
-      // in which case it rejects credentials immediately. Re-read its state so
-      // the re-render shows the connected screen instead of a Wi-Fi form that
-      // can never succeed. Skip legacy devices (no network state): they can't
-      // be online without Wi-Fi, and probing 0x07 would overwrite the
-      // "Unable to connect" error the form is about to display.
+      // A device that left Wi-Fi mode mid-flow rejects credentials immediately; re-read
+      // its state so the re-render shows the connected screen. Legacy devices skip the
+      // probe — it would overwrite the "Unable to connect" error the form shows.
       if (this._networkState) {
         const provisionError = this._client!.error;
         await this._refreshDeviceState();

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -1028,11 +1028,31 @@ export class EwtInstallDialog extends LitElement {
 
     // Give a device that comes back empty-handed a little longer before we
     // show the form and tell the user there are no networks.
-    this._scanGraceTimeout = setTimeout(() => {
+    this._scanGraceTimeout = setTimeout(async () => {
       this._scanGraceTimeout = undefined;
-      if (this._ssids === undefined) {
+      if (this._ssids !== undefined || this._state !== "PROVISION") {
+        return;
+      }
+      // Nothing found within the grace period. On a Wi-Fi-capable device an
+      // empty scan is suspicious: it is also what we see when the device
+      // rebooted onto another interface mid-flow (e.g. it detected an Ethernet
+      // link and disabled Wi-Fi) — the reboot is invisible to us, and the new
+      // boot still answers scans with empty lists. Re-read the device state
+      // before showing a Wi-Fi form that may no longer be able to succeed.
+      // Stop scanning first so the state RPCs don't overlap an in-flight scan.
+      await this._stopScanning();
+      await this._refreshDeviceState();
+      if (this._showsProvisionForm) {
+        // Still provisioning Wi-Fi: show the form with manual entry.
+        // `_syncScanning` resumes the subscription from `updated()`.
         this._ssids = [];
         this._selectedSsid = null;
+      } else {
+        // The device left Wi-Fi provisioning mid-scan (e.g. it is now online
+        // via Ethernet). `state`/`networkState` aren't reactive properties, so
+        // re-render explicitly; `_renderProvision` picks the right screen and
+        // scanning stays stopped.
+        this.requestUpdate();
       }
     }, SCAN_GRACE_PERIOD);
 
@@ -1259,6 +1279,22 @@ export class EwtInstallDialog extends LitElement {
       // packet rejects the *next* RPC we send (the resumed network scan) instead of this one.
       await this._client!.provision(ssid, password, PROVISION_CONNECT_TIMEOUT);
     } catch (err: any) {
+      // Provisioning failed. One cause: the device left Wi-Fi mode mid-flow
+      // (e.g. it detected an Ethernet link and rebooted with Wi-Fi disabled),
+      // in which case it rejects credentials immediately. Re-read its state so
+      // the re-render shows the connected screen instead of a Wi-Fi form that
+      // can never succeed. Skip legacy devices (no network state): they can't
+      // be online without Wi-Fi, and probing 0x07 would overwrite the
+      // "Unable to connect" error the form is about to display.
+      if (this._client!.networkState) {
+        const provisionError = this._client!.error;
+        await this._refreshDeviceState();
+        if (!this._connectedWithoutWifi) {
+          // Staying on the form after a genuine Wi-Fi failure: restore the
+          // provision error in case a refresh RPC (e.g. a timeout) replaced it.
+          this._client!.error = provisionError;
+        }
+      }
       return;
     } finally {
       // If we end up back on the network form, `_syncScanning` resumes scanning.

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -133,6 +133,13 @@ export class EwtInstallDialog extends LitElement {
   // so the progress label reads "Connecting to the network" rather than "Scanning for networks".
   @state() private _connectingToNetwork = false;
 
+  // Monotonic id for the current page, bumped on every `_state` change. Async provisioning
+  // continuations (the `_enterProvision` wait loop, the scan-grace callback) capture it and
+  // bail once it moves on: `_state === "PROVISION"` alone can't tell a new provisioning
+  // session from the one they were started for, so without this a continuation that survives
+  // a quick leave-and-re-enter would keep mutating the new session's state.
+  private _provisionGeneration = 0;
+
   // undefined = not loaded
   // null = not available
   @state() private _ssids?: Ssid[] | null;
@@ -246,9 +253,17 @@ export class EwtInstallDialog extends LitElement {
         : net.supportsWifi && state !== ImprovSerialCurrentState.STOPPED;
     // The device may be online via a non-Wi-Fi interface (Ethernet); surface its reachable
     // URL and the "online" affordances even when the Wi-Fi state machine isn't PROVISIONED.
-    const deviceUrl = this._client!.nextUrl ?? net?.urls?.[0];
+    const deviceUrl = this._deviceUrl;
     const isOnline =
       state === ImprovSerialCurrentState.PROVISIONED || net?.isOnline === true;
+    // Wi-Fi is unavailable but the device isn't online yet over its other interface (e.g.
+    // Ethernet cable unplugged): still offer the provisioning flow, which waits for that
+    // interface to come up instead of showing a Wi-Fi form (see _enterProvision). Without
+    // this the dashboard would have no network affordance at all in that state.
+    const awaitNetwork =
+      state === ImprovSerialCurrentState.STOPPED &&
+      !isOnline &&
+      this._canComeOnlineWithoutWifi;
 
     content = html`
       <div slot="content">
@@ -303,7 +318,7 @@ export class EwtInstallDialog extends LitElement {
                   <div slot="headline">Add to Home Assistant</div>
                 </ew-list-item>
               `}
-          ${!showWifi
+          ${!showWifi && !awaitNetwork
             ? ""
             : html`
                 <ew-list-item
@@ -320,10 +335,12 @@ export class EwtInstallDialog extends LitElement {
                 >
                   ${listItemWifi}
                   <div slot="headline">
-                    ${this._client!.state ===
-                    ImprovSerialCurrentState.PROVISIONED
-                      ? "Change Wi-Fi"
-                      : "Connect to Wi-Fi"}
+                    ${awaitNetwork
+                      ? "Connect to network"
+                      : this._client!.state ===
+                          ImprovSerialCurrentState.PROVISIONED
+                        ? "Change Wi-Fi"
+                        : "Connect to Wi-Fi"}
                   </div>
                 </ew-list-item>
               `}
@@ -465,10 +482,7 @@ export class EwtInstallDialog extends LitElement {
         this._client!.state === ImprovSerialCurrentState.PROVISIONED)
     ) {
       heading = undefined;
-      // A device online via a non-Wi-Fi interface (e.g. Ethernet) has no Wi-Fi nextUrl; fall
-      // back to the reachable URL reported in its network state.
-      const deviceUrl =
-        this._client!.nextUrl ?? this._client!.networkState?.urls?.[0];
+      const deviceUrl = this._deviceUrl;
       const showSetupLinks =
         !this._wasProvisioned &&
         (deviceUrl !== undefined || "home_assistant_domain" in this._manifest);
@@ -896,6 +910,8 @@ export class EwtInstallDialog extends LitElement {
     if (this._state !== "ERROR") {
       this._error = undefined;
     }
+    // Invalidate async continuations started for the previous page.
+    this._provisionGeneration++;
     if (this._state === "PROVISION") {
       // Re-query device/network state, then either let `_syncScanning` scan (Wi-Fi available)
       // or wait for the device to come online via another interface (e.g. Ethernet). This also
@@ -923,6 +939,23 @@ export class EwtInstallDialog extends LitElement {
     );
   }
 
+  // The device has a network interface other than Wi-Fi (e.g. Ethernet), so it can come
+  // online without Wi-Fi provisioning.
+  private get _canComeOnlineWithoutWifi(): boolean {
+    const net = this._client?.networkState;
+    return (
+      net !== undefined &&
+      (net.supportsEthernet || net.supportsThread || net.supportsModem)
+    );
+  }
+
+  // A Wi-Fi-provisioned device reports its URL via nextUrl; a device online via another
+  // interface (e.g. Ethernet) has no nextUrl and instead reports reachable URLs in its
+  // network state.
+  private get _deviceUrl(): string | undefined {
+    return this._client?.nextUrl ?? this._client?.networkState?.urls?.[0];
+  }
+
   // Re-read the device's current state + network state. Bounded so an unresponsive device
   // (e.g. rebooting to switch network interface) can't hang us; errors are non-fatal and leave
   // the last-known values in place.
@@ -941,61 +974,63 @@ export class EwtInstallDialog extends LitElement {
     // falling through to the SSID form, which would dereference this._ssids before it's loaded.
     this._ssids = undefined;
     this._busy = true;
-
     this._connectingToNetwork = false;
 
-    // The device's Wi-Fi availability can change after we first read it at connect time
-    // (e.g. a dual-interface device that detects an Ethernet link and disables Wi-Fi). Re-query
-    // before provisioning so we don't offer a Wi-Fi form / scan that can't succeed.
-    await this._refreshDeviceState();
-
-    // Wi-Fi provisioning is available unless the state machine reports STOPPED. If it is, drop
-    // `_busy` and let `_syncScanning` (driven from `updated()`) start the scan and show the form.
-    if (this._client?.state !== ImprovSerialCurrentState.STOPPED) {
-      this._busy = false;
-      return;
-    }
-
-    // Wi-Fi can't be provisioned here (no Wi-Fi, or Wi-Fi disabled because the device runs on
-    // another interface). If it's already online elsewhere, show the connected screen now.
-    if (this._connectedWithoutWifi) {
-      this._busy = false;
-      return;
-    }
-
-    // If the device can come online without Wi-Fi (e.g. Ethernet), wait for that — the analog of
-    // the Wi-Fi connect wait — so we land on the "Device connected" screen (with the Add to Home
-    // Assistant / Visit Device links) once the link is up.
-    const net = this._client?.networkState;
-    const canComeOnlineWithoutWifi =
-      net !== undefined &&
-      (net.supportsEthernet || net.supportsThread || net.supportsModem);
-    if (!canComeOnlineWithoutWifi) {
-      // Wi-Fi is the only path and it's disabled -> "Wi-Fi off" message.
-      this._busy = false;
-      return;
-    }
-
-    this._connectingToNetwork = true;
-    for (
-      let i = 0;
-      i < ONLINE_WAIT_MAX_TRIES && this._state === "PROVISION";
-      i++
-    ) {
-      await sleep(2000);
-      if (this._state !== "PROVISION") {
-        return; // user navigated away
-      }
+    // Bail after every await once the page moves on: a newer invocation (or no provisioning at
+    // all) owns the flags then. The same guard on the finally keeps a superseded invocation
+    // from stomping the newer one's spinner.
+    const gen = this._provisionGeneration;
+    try {
+      // The device's Wi-Fi availability can change after we first read it at connect time
+      // (e.g. a dual-interface device that detects an Ethernet link and disables Wi-Fi). Re-query
+      // before provisioning so we don't offer a Wi-Fi form / scan that can't succeed.
       await this._refreshDeviceState();
-      if (this._connectedWithoutWifi) {
-        this._connectingToNetwork = false;
-        this._busy = false; // -> connected screen
+      if (gen !== this._provisionGeneration) {
         return;
       }
+
+      // Wi-Fi provisioning is available unless the state machine reports STOPPED. Dropping
+      // `_busy` (in the finally) lets `_syncScanning` (driven from `updated()`) start the scan
+      // and show the form.
+      if (this._client?.state !== ImprovSerialCurrentState.STOPPED) {
+        return;
+      }
+
+      // Wi-Fi can't be provisioned here (no Wi-Fi, or Wi-Fi disabled because the device runs on
+      // another interface). If it's already online elsewhere, show the connected screen now.
+      if (this._connectedWithoutWifi) {
+        return;
+      }
+
+      // If the device can come online without Wi-Fi (e.g. Ethernet), wait for that — the analog
+      // of the Wi-Fi connect wait — so we land on the "Device connected" screen (with the Add to
+      // Home Assistant / Visit Device links) once the link is up.
+      if (!this._canComeOnlineWithoutWifi) {
+        // Wi-Fi is the only path and it's disabled -> "Wi-Fi off" message.
+        return;
+      }
+
+      this._connectingToNetwork = true;
+      for (let i = 0; i < ONLINE_WAIT_MAX_TRIES; i++) {
+        await sleep(2000);
+        if (gen !== this._provisionGeneration) {
+          return;
+        }
+        await this._refreshDeviceState();
+        if (gen !== this._provisionGeneration) {
+          return;
+        }
+        if (this._connectedWithoutWifi) {
+          return; // -> connected screen
+        }
+      }
+      // Gave up waiting. _renderProvision shows a "not connected yet" message.
+    } finally {
+      if (gen === this._provisionGeneration) {
+        this._connectingToNetwork = false;
+        this._busy = false;
+      }
     }
-    // Gave up waiting; stop the spinner. _renderProvision shows a "not connected yet" message.
-    this._connectingToNetwork = false;
-    this._busy = false;
   }
 
   /**
@@ -1040,8 +1075,15 @@ export class EwtInstallDialog extends LitElement {
       // boot still answers scans with empty lists. Re-read the device state
       // before showing a Wi-Fi form that may no longer be able to succeed.
       // Stop scanning first so the state RPCs don't overlap an in-flight scan.
+      const gen = this._provisionGeneration;
       await this._stopScanning();
       await this._refreshDeviceState();
+      // The awaits above run for seconds on an unresponsive device (RPC timeouts). If the user
+      // left provisioning — or left and re-entered — meanwhile, the new page owns scanning and
+      // `_ssids`; a late scan result may also have filled `_ssids` while we stopped.
+      if (gen !== this._provisionGeneration || this._ssids !== undefined) {
+        return;
+      }
       if (this._showsProvisionForm) {
         // Still provisioning Wi-Fi: show the form with manual entry.
         // `_syncScanning` resumes the subscription from `updated()`.

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -1289,10 +1289,7 @@ export class EwtInstallDialog extends LitElement {
           );
           break;
         } catch (err) {
-          if (
-            client.error !== ImprovSerialErrorState.TIMEOUT ||
-            attempt >= 2
-          ) {
+          if (client.error !== ImprovSerialErrorState.TIMEOUT || attempt >= 2) {
             this.logger.debug(`Device does not report network state: ${err}`);
             break;
           }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -935,6 +935,12 @@ export class EwtInstallDialog extends LitElement {
       this._connectingToNetwork = false;
     }
 
+    if (this._state === "DASHBOARD") {
+      // The dashboard is otherwise a one-shot snapshot; keep it converging for
+      // a device that's about to come online via a non-Wi-Fi interface.
+      this._watchNetworkStateUntilOnline();
+    }
+
     if (this._state === "INSTALL") {
       this._installConfirmed = false;
       this._installState = undefined;
@@ -966,6 +972,38 @@ export class EwtInstallDialog extends LitElement {
   // network state.
   private get _deviceUrl(): string | undefined {
     return this._client?.nextUrl ?? this._networkState?.urls?.[0];
+  }
+
+  // While the dashboard shows a device that could come online via a non-Wi-Fi interface but
+  // isn't yet (e.g. it was just reset from the console and its Ethernet link is still coming
+  // up), poll its network state so the dashboard converges to the online affordances without
+  // user interaction. Ends when the device reports online, the page or client changes, or
+  // after the same bound as the provisioning wait.
+  private async _watchNetworkStateUntilOnline() {
+    const gen = this._provisionGeneration;
+    const client = this._client;
+    for (let i = 0; i < ONLINE_WAIT_MAX_TRIES; i++) {
+      if (
+        this._state !== "DASHBOARD" ||
+        gen !== this._provisionGeneration ||
+        this._client !== client ||
+        !client ||
+        client.state !== ImprovSerialCurrentState.STOPPED ||
+        this._networkState?.online !== false ||
+        !this._canComeOnlineWithoutWifi
+      ) {
+        return;
+      }
+      await sleep(2000);
+      if (
+        this._state !== "DASHBOARD" ||
+        gen !== this._provisionGeneration ||
+        this._client !== client
+      ) {
+        return;
+      }
+      await this._refreshDeviceState();
+    }
   }
 
   // Re-read the device's current state + network state. Bounded so an unresponsive device
@@ -1264,6 +1302,10 @@ export class EwtInstallDialog extends LitElement {
         // Don't leave the probe's failure behind as the device error.
         client.error = ImprovSerialErrorState.NO_ERROR;
       }
+      // Needed here as well as in `willUpdate`: on first connect DASHBOARD is
+      // the initial page (no state change), and on re-init after the logs page
+      // the client didn't exist yet when `willUpdate` ran.
+      this._watchNetworkStateUntilOnline();
     } catch (err: any) {
       // Clear old value
       this._info = undefined;

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -115,9 +115,12 @@ export class EwtInstallDialog extends LitElement {
   @state() private _client?: ImprovSerial | null;
 
   // Connectivity + interface inventory from the device's network state; undefined when the
-  // device predates the command. The SDK returns rather than stores it, so we keep it here —
-  // refreshed in _initialize and _refreshDeviceState, whose callers trigger the re-renders.
-  private _networkState?: NetworkState;
+  // device predates the command. The SDK returns rather than stores it, so we keep it here,
+  // refreshed in _initialize and _refreshDeviceState. Reactive because refreshes complete
+  // after the render that a new `_client` (or a page change) already triggered — the dashboard
+  // would otherwise keep showing the pre-probe snapshot (e.g. "Connect to Wi-Fi" on an
+  // Ethernet-connected device after returning from the logs page).
+  @state() private _networkState?: NetworkState;
 
   @state() private _state:
     | "ERROR"


### PR DESCRIPTION
## What

Teaches the install dialog about devices whose network connectivity isn't (only) Wi-Fi, using the network-state API (`0x07`) added in improv-wifi-serial-sdk 2.8.0 / esphome's `improv_serial` extension:

- The dashboard probes the device's network state on connect and shows the right affordances: **Visit Device** / **Add to Home Assistant** for a device online via Ethernet (not just `PROVISIONED` Wi-Fi), **Connect to network** (a wait-for-link flow) for an offline device that can come online without Wi-Fi, and the Wi-Fi items only when the device actually has usable Wi-Fi.
- Entering provisioning re-queries the device: dual-interface devices that disabled Wi-Fi mid-flow (e.g. detected an Ethernet link and rebooted) land on the connected screen or a wait, instead of a Wi-Fi form that can never succeed. Provisioning failures and empty scans re-check for the same reason.
- The dashboard and the provisioning wait poll network state (2s cadence, bounded) so the UI converges when a link comes up, with a generation counter cancelling stale continuations on page changes and dialog close.
- Legacy devices (no `0x07` support) keep the existing Wi-Fi-only behavior, including a timeout-retried probe so a busy just-flashed device isn't misclassified as legacy.

Also includes hardening from a review pass: bounded state-refresh RPCs, centralized device-error restoration (no spurious "Timeout" on the form), early exit from waits when the device changes state, and a close affordance on the long-running busy screens.

## Testing

Exercised against real hardware: a legacy Wi-Fi device (pre-`0x07` firmware), a current Wi-Fi-only device, and a dual Wi-Fi+Ethernet (W5500) device — including mid-flow interface switches, wrong-password provisioning, unresponsive-device timeouts, and close/reopen during active polling.

## Dependencies

Depends on improv-wifi/sdk-serial-js#161 (`requestCurrentState(timeout)` and stale-`nextUrl` clearing), released in improv-wifi-serial-sdk 2.8.1 — the pin is bumped accordingly.
