### PR TITLE
Small install-dialog fixes and improv-wifi-serial-sdk 2.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@material/web": "^2.2.0",
         "esptool-js": "^0.6.0",
-        "improv-wifi-serial-sdk": "2.8.0",
+        "improv-wifi-serial-sdk": "2.8.1",
         "lit": "^3.2.1",
         "tslib": "^2.8.1"
       },
@@ -3230,9 +3230,9 @@
       }
     },
     "node_modules/improv-wifi-serial-sdk": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
-      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.1.tgz",
+      "integrity": "sha512-KU2D7bNbdUDUX0JK2nQGTGTuxJNH+loXyMR6DXBIzAh4/2dwiR2cxK0igvl+dLWjf4wRv43iUn/eQuUClw5V3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/web": "^2.4.1",
@@ -6273,9 +6273,9 @@
       "dev": true
     },
     "improv-wifi-serial-sdk": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.0.tgz",
-      "integrity": "sha512-3MCm9NAD6c4OXyXl+jPqu0kNasIZi80JVeDkPaOQEI4JpItCaOAyQGdL/yg5mOqlKJ0nn2K/xb8H7enbNPc/5g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/improv-wifi-serial-sdk/-/improv-wifi-serial-sdk-2.8.1.tgz",
+      "integrity": "sha512-KU2D7bNbdUDUX0JK2nQGTGTuxJNH+loXyMR6DXBIzAh4/2dwiR2cxK0igvl+dLWjf4wRv43iUn/eQuUClw5V3g==",
       "requires": {
         "@material/web": "^2.4.1",
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@material/web": "^2.2.0",
     "esptool-js": "^0.6.0",
-    "improv-wifi-serial-sdk": "2.8.0",
+    "improv-wifi-serial-sdk": "2.8.1",
     "lit": "^3.2.1",
     "tslib": "^2.8.1"
   }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -723,7 +723,7 @@ export class EwtInstallDialog extends LitElement {
           ${this._installState.chipFamily === "ESP8266"
             ? "a minute"
             : "2 minutes"}.<br />
-          Keep this page visible to prevent slow down
+          Keep this page visible for fastest installation.
         `,
         percentage,
       );
@@ -872,7 +872,7 @@ export class EwtInstallDialog extends LitElement {
     // show the form and tell the user there are no networks.
     this._scanGraceTimeout = setTimeout(() => {
       this._scanGraceTimeout = undefined;
-      if (this._ssids === undefined) {
+      if (this._ssids === undefined && this._state === "PROVISION") {
         this._ssids = [];
         this._selectedSsid = null;
       }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -829,6 +829,11 @@ export class EwtInstallDialog extends LitElement {
     // `_syncScanning` picks it up from here.
     if (this._state === "PROVISION") {
       this._ssids = undefined;
+      // The client never resets its error itself, so an old one (e.g. a
+      // timed-out scan) would otherwise render on the form forever.
+      if (this._client) {
+        this._client.error = ImprovSerialErrorState.NO_ERROR;
+      }
     } else {
       // Reset this value if we leave provisioning.
       this._provisionForce = false;


### PR DESCRIPTION
## What

Four small fixes split out of #721, per review feedback there:

- Bump improv-wifi-serial-sdk to 2.8.1, which clears a stale `nextUrl` on the client so "Visit Device" can't point at a URL from a previous provisioning session, and adds an optional timeout to `requestCurrentState`.
- Clear the Improv client's error when entering provisioning. The client never resets it on its own (only new error packets and local RPC timeouts write it), so e.g. a Wi-Fi scan interrupted by a device reset latches a "Timeout" that then renders on the credentials form forever, surviving navigation out of and back into the page. Reproduced on hardware: enter Configure Wi-Fi, hold the device's reset button for a moment — 30s later (the SDK's scan timeout) the red "Timeout" appears and never leaves.
- Guard the scan grace-period timer so a late tick can't populate the network form state after the user has already left the provisioning page.
- Reword the install progress hint ("Keep this page visible for fastest installation.").