### PR TITLE
Show online dashboard options for devices on non-Wi-Fi interfaces

### DIFF
--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -31,7 +31,11 @@ import {
   networkWifiFull,
 } from "./components/svg";
 import { Logger, Manifest, FlashStateType, FlashState } from "./const.js";
-import { ImprovSerial, Ssid } from "improv-wifi-serial-sdk/dist/serial";
+import {
+  ImprovSerial,
+  NetworkState,
+  Ssid,
+} from "improv-wifi-serial-sdk/dist/serial";
 import {
   ImprovSerialCurrentState,
   ImprovSerialErrorState,
@@ -52,6 +56,11 @@ console.log(
 
 const ERROR_ICON = "⚠️";
 const OK_ICON = "🎉";
+
+// Network state is polled in the background, so a failed request can recover
+// on a later tick; keep the timeout small to avoid queueing up requests.
+const NETWORK_STATE_TIMEOUT = 500;
+const NETWORK_STATE_POLL_INTERVAL = 2500;
 
 // A device that just booted can come back from its first scan with no networks
 // at all. Keep looking (the SDK scans every 3s, so this covers four scans)
@@ -94,6 +103,12 @@ export class EwtInstallDialog extends LitElement {
 
   // null = NOT_SUPPORTED
   @state() private _client?: ImprovSerial | null;
+
+  // undefined = not yet known
+  // null = the device doesn't support the network state command
+  @state() private _networkState?: NetworkState | null;
+
+  private _networkStatePollInterval?: ReturnType<typeof setInterval>;
 
   @state() private _state:
     | "ERROR"
@@ -249,20 +264,19 @@ export class EwtInstallDialog extends LitElement {
                 </ew-list-item>
               `
             : ""}
-          ${this._client!.nextUrl === undefined
+          ${this._deviceUrl === undefined
             ? ""
             : html`
                 <ew-list-item
                   type="link"
-                  href=${this._client!.nextUrl}
+                  href=${this._deviceUrl}
                   target="_blank"
                 >
                   ${listItemVisitDevice}
                   <div slot="headline">Visit Device</div>
                 </ew-list-item>
               `}
-          ${!this._manifest.home_assistant_domain ||
-          this._client!.state !== ImprovSerialCurrentState.PROVISIONED
+          ${!this._manifest.home_assistant_domain || !this._isOnline
             ? ""
             : html`
                 <ew-list-item
@@ -845,6 +859,68 @@ export class EwtInstallDialog extends LitElement {
     }
   }
 
+  // Online via provisioned Wi-Fi or any other interface (e.g. Ethernet).
+  private get _isOnline(): boolean {
+    return (
+      this._client?.state === ImprovSerialCurrentState.PROVISIONED ||
+      this._networkState?.online === true
+    );
+  }
+
+  // A Wi-Fi-provisioned device reports its URL via `nextUrl`; one online via
+  // another interface (e.g. Ethernet) reports it in its network state.
+  private get _deviceUrl(): string | undefined {
+    return this._client?.nextUrl ?? this._networkState?.urls[0];
+  }
+
+  // Poll network state while (and only while) the dashboard is shown, so the
+  // menu converges when the device comes online (e.g. Ethernet link up).
+  // Driven from `updated()`, like `_syncScanning`.
+  private _syncNetworkStatePolling() {
+    const shouldPoll =
+      this._state === "DASHBOARD" &&
+      !!this._client &&
+      this._networkState !== null;
+
+    if (shouldPoll === (this._networkStatePollInterval !== undefined)) {
+      return;
+    }
+
+    if (!shouldPoll) {
+      clearInterval(this._networkStatePollInterval);
+      this._networkStatePollInterval = undefined;
+      return;
+    }
+
+    this._refreshNetworkState();
+    this._networkStatePollInterval = setInterval(
+      () => this._refreshNetworkState(),
+      NETWORK_STATE_POLL_INTERVAL,
+    );
+  }
+
+  private async _refreshNetworkState() {
+    const client = this._client;
+    if (!client) {
+      return;
+    }
+    const error = client.error;
+    try {
+      this._networkState = await client.requestNetworkState(
+        NETWORK_STATE_TIMEOUT,
+      );
+    } catch (err) {
+      if (client.error === ImprovSerialErrorState.UNKNOWN_RPC_COMMAND) {
+        // The device predates the command; stop asking.
+        this._networkState = null;
+      }
+      this.logger.debug(`Failed to fetch network state: ${err}`);
+      // Keep the last-known state; a failed poll must not leave its error
+      // behind on the client (the provision form renders `client.error`).
+      client.error = error;
+    }
+  }
+
   /**
    * Return if the provision page shows the network form (and not a message).
    */
@@ -950,6 +1026,7 @@ export class EwtInstallDialog extends LitElement {
     }
 
     this._syncScanning();
+    this._syncNetworkStatePolling();
 
     if (this._state !== "PROVISION") {
       return;
@@ -1001,6 +1078,8 @@ export class EwtInstallDialog extends LitElement {
     }
 
     const client = new ImprovSerial(this.port!, this.logger);
+    // Don't carry network state over from a previous client (e.g. pre-install).
+    this._networkState = undefined;
     client.addEventListener("state-changed", () => {
       this.requestUpdate();
     });
@@ -1124,6 +1203,8 @@ export class EwtInstallDialog extends LitElement {
   }
 
   private async _handleClose() {
+    clearInterval(this._networkStatePollInterval);
+    this._networkStatePollInterval = undefined;
     if (this._client) {
       await this._closeClientWithoutEvents(this._client);
     }

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -876,7 +876,7 @@ export class EwtInstallDialog extends LitElement {
   // Poll network state while (and only while) the dashboard is shown, so the
   // menu converges when the device comes online (e.g. Ethernet link up).
   // Driven from `updated()`, like `_syncScanning`.
-  private _syncNetworkStatePolling() {
+  private _setupNetworkStatePolling() {
     const shouldPoll =
       this._state === "DASHBOARD" &&
       !!this._client &&
@@ -887,38 +887,38 @@ export class EwtInstallDialog extends LitElement {
     }
 
     if (!shouldPoll) {
-      clearInterval(this._networkStatePollInterval);
-      this._networkStatePollInterval = undefined;
+      this._stopNetworkStatePolling();
       return;
     }
 
-    this._refreshNetworkState();
+    const refresh = async () => {
+      const client = this._client;
+      if (!client) {
+        return;
+      }
+      try {
+        this._networkState = await client.requestNetworkState(
+          NETWORK_STATE_TIMEOUT,
+        );
+      } catch (err) {
+        if (client.error === ImprovSerialErrorState.UNKNOWN_RPC_COMMAND) {
+          // The device predates the command; stop asking.
+          this._networkState = null;
+          this._stopNetworkStatePolling();
+        }
+        this.logger.debug(`Failed to fetch network state: ${err}`);
+      }
+    };
+    refresh();
     this._networkStatePollInterval = setInterval(
-      () => this._refreshNetworkState(),
+      refresh,
       NETWORK_STATE_POLL_INTERVAL,
     );
   }
 
-  private async _refreshNetworkState() {
-    const client = this._client;
-    if (!client) {
-      return;
-    }
-    const error = client.error;
-    try {
-      this._networkState = await client.requestNetworkState(
-        NETWORK_STATE_TIMEOUT,
-      );
-    } catch (err) {
-      if (client.error === ImprovSerialErrorState.UNKNOWN_RPC_COMMAND) {
-        // The device predates the command; stop asking.
-        this._networkState = null;
-      }
-      this.logger.debug(`Failed to fetch network state: ${err}`);
-      // Keep the last-known state; a failed poll must not leave its error
-      // behind on the client (the provision form renders `client.error`).
-      client.error = error;
-    }
+  private _stopNetworkStatePolling() {
+    clearInterval(this._networkStatePollInterval);
+    this._networkStatePollInterval = undefined;
   }
 
   /**
@@ -1026,7 +1026,7 @@ export class EwtInstallDialog extends LitElement {
     }
 
     this._syncScanning();
-    this._syncNetworkStatePolling();
+    this._setupNetworkStatePolling();
 
     if (this._state !== "PROVISION") {
       return;
@@ -1203,14 +1203,18 @@ export class EwtInstallDialog extends LitElement {
   }
 
   private async _handleClose() {
-    clearInterval(this._networkStatePollInterval);
-    this._networkStatePollInterval = undefined;
     if (this._client) {
       await this._closeClientWithoutEvents(this._client);
     }
     fireEvent(this, "closed" as any);
     document.body.style.overflow = this._bodyOverflow!;
     this.parentNode!.removeChild(this);
+  }
+
+  public override disconnectedCallback() {
+    super.disconnectedCallback();
+    // The interval would otherwise keep firing against the closed client.
+    this._stopNetworkStatePolling();
   }
 
   /**


### PR DESCRIPTION
## What

First feature step of splitting up #721, starting where discussion there suggested: query network state and adjust the main menu when the device is online via another interface.

- While the dashboard is shown, poll the device's network state (Improv `0x07`, improv-wifi-serial-sdk 2.8.0+) every 2.5s with a small (500ms) per-request timeout, so opening the dialog is never delayed and the menu converges when the device comes online (e.g. an Ethernet cable is plugged in). Polling starts/stops from `updated()` based on the current page, mirroring `_syncScanning`, and the interval is cleared on dialog close.
- **Visit Device** now also shows for a device that reports a URL in its network state (online via Ethernet) rather than only via `nextUrl` (Wi-Fi provisioning), and **Add to Home Assistant** shows whenever the device is online, not only when Wi-Fi is `PROVISIONED`.
- Devices that don't implement the command answer `UNKNOWN_RPC_COMMAND`; polling stops for them and everything behaves as before. A failed poll keeps the last-known state and restores the client's previous error so it can't surface as a spurious device error elsewhere.

No changes to the Wi-Fi menu item or the provisioning flow yet — those follow in later PRs.

## Dependencies

Based on #722 (improv-wifi-serial-sdk 2.8.1 bump); will retarget to `main` once that merges.

## Testing

- `npm ci && script/build && prettier --check src` pass.
- Hardware pass still to do (legacy Wi-Fi device, Wi-Fi-only device, dual Wi-Fi+Ethernet) before marking ready for review.