### PR TITLE
Add an awaited post-flash callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
+      - run: npm test
       - run: script/build
       - run: npm exec -- prettier --check src

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Allow flashing ESPHome or other ESP-based firmwares via the browser. Will automa
 ></esp-web-install-button>
 ```
 
+To read serial output after a successful flash, set `onPostFlash` on the
+install button:
+
+```js
+const button = document.querySelector("esp-web-install-button");
+button.onPostFlash = async (port) => {
+  const reader = port.readable.getReader();
+  try {
+    // Read the firmware output here.
+  } finally {
+    reader.releaseLock();
+  }
+};
+```
+
+ESP Web Tools opens the port at 115200 baud before it calls the function. It
+waits for the function before it starts Improv initialization. The function
+must release all stream locks and leave the port open before it returns. An
+error is logged, but it does not change the successful flash result.
+
 Example manifest:
 
 The optional `serialType` field (`"cdc"` or `"uart"`) lets you ship separate firmware variants for chips that support both native USB CDC (built-in USB) and external USB-to-UART bridges. The correct variant is selected automatically based on the detected connection. Builds without a `serialType` are used as a fallback for any connection type.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "ESPHome maintainers",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "script/build"
+    "prepublishOnly": "script/build",
+    "test": "bash script/test"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",

--- a/script/test
+++ b/script/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+npm exec -- tsc
+node --no-warnings --test test/*.test.mjs

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -31,6 +31,7 @@ export const connect = async (button: InstallButton) => {
   el.port = port;
   el.manifestPath = button.manifest || button.getAttribute("manifest")!;
   el.overrides = button.overrides;
+  el.onPostFlash = button.onPostFlash;
   el.addEventListener(
     "closed",
     () => {

--- a/src/install-button.ts
+++ b/src/install-button.ts
@@ -68,6 +68,16 @@ export class InstallButton extends HTMLElement {
 
   public overrides: EwtInstallDialog["overrides"];
 
+  /**
+   * Runs once after a successful flash and after the serial port reopens at
+   * 115200 baud. ESP Web Tools waits for this callback before it starts
+   * post-flash initialization. Release all serial stream locks before the
+   * callback returns, and leave the port open.
+   *
+   * A callback error is logged and does not change the flash result.
+   */
+  public onPostFlash?: EwtInstallDialog["onPostFlash"];
+
   public connectedCallback() {
     if (this.renderRoot) {
       return;

--- a/src/install-dialog.ts
+++ b/src/install-dialog.ts
@@ -45,6 +45,7 @@ import { downloadManifest } from "./util/manifest";
 import { dialogStyles } from "./styles";
 import { version } from "./version";
 import type { EwFilledSelect } from "./components/ew-filled-select";
+import { runPostFlash, type PostFlashCallback } from "./post-flash.js";
 
 console.log(
   `ESP Web Tools ${version} by Open Home Foundation; https://esphome.github.io/esp-web-tools/`,
@@ -87,6 +88,8 @@ export class EwtInstallDialog extends LitElement {
       deviceImprov: ImprovSerial["info"],
     ) => boolean;
   };
+
+  public onPostFlash?: PostFlashCallback;
 
   private _manifest!: Manifest;
 
@@ -1056,9 +1059,14 @@ export class EwtInstallDialog extends LitElement {
 
         if (state.state === FlashStateType.FINISHED) {
           sleep(100)
-            // Flashing closes the port
-            .then(() => this.port.open({ baudRate: 115200, bufferSize: 8192 }))
-            .then(() => this._initialize(true))
+            .then(() =>
+              runPostFlash(
+                this.port,
+                this.onPostFlash,
+                () => this._initialize(true),
+                this.logger,
+              ),
+            )
             .then(() => this.requestUpdate());
         } else if (state.state === FlashStateType.ERROR) {
           sleep(100)

--- a/src/post-flash.ts
+++ b/src/post-flash.ts
@@ -1,0 +1,19 @@
+import type { Logger } from "./const.js";
+
+export type PostFlashCallback = (port: SerialPort) => void | Promise<void>;
+
+export const runPostFlash = async (
+  port: SerialPort,
+  callback: PostFlashCallback | undefined,
+  initialize: () => void | Promise<void>,
+  logger: Logger,
+) => {
+  // Flashing closes the port. Reopen it before the callback reads boot output.
+  await port.open({ baudRate: 115200, bufferSize: 8192 });
+  try {
+    await callback?.(port);
+  } catch (error) {
+    logger.error("Post-flash callback failed.", error);
+  }
+  await initialize();
+};

--- a/test/post-flash.test.mjs
+++ b/test/post-flash.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runPostFlash } from "../dist/post-flash.js";
+
+const makePort = (steps) => ({
+  open: async (options) => {
+    assert.deepEqual(options, { baudRate: 115200, bufferSize: 8192 });
+    steps.push("open");
+  },
+});
+
+test("runs the callback after the port opens and before initialization", async () => {
+  const steps = [];
+  const port = makePort(steps);
+
+  await runPostFlash(
+    port,
+    async (callbackPort) => {
+      assert.equal(callbackPort, port);
+      steps.push("callback-start");
+      await Promise.resolve();
+      steps.push("callback-end");
+    },
+    async () => {
+      steps.push("initialize");
+    },
+    console,
+  );
+
+  assert.deepEqual(steps, [
+    "open",
+    "callback-start",
+    "callback-end",
+    "initialize",
+  ]);
+});
+
+test("continues initialization when the callback fails", async () => {
+  const steps = [];
+  const errors = [];
+  const failure = new Error("callback failed");
+
+  await runPostFlash(
+    makePort(steps),
+    async () => {
+      steps.push("callback");
+      throw failure;
+    },
+    async () => {
+      steps.push("initialize");
+    },
+    {
+      log() {},
+      error(...args) {
+        errors.push(args);
+      },
+    },
+  );
+
+  assert.deepEqual(steps, ["open", "callback", "initialize"]);
+  assert.deepEqual(errors, [["Post-flash callback failed.", failure]]);
+});
+
+test("continues without a callback", async () => {
+  const steps = [];
+
+  await runPostFlash(
+    makePort(steps),
+    undefined,
+    () => {
+      steps.push("initialize");
+    },
+    console,
+  );
+
+  assert.deepEqual(steps, ["open", "initialize"]);
+});


### PR DESCRIPTION
## Summary

- Add an awaited `onPostFlash` callback to the install button.
- Pass the open `SerialPort` to the callback before Improv initialization.
- Document the stream-lock, open-port, and error contract.
- Add unit tests and run them in pull-request CI.

## Why

After a successful flash, ESP Web Tools resets the device, disconnects the flash transport, reopens the serial port, and starts Improv initialization. An installer can need exclusive access to the new firmware output in that short interval.

The existing `closed` event can also follow a cancel and has no flash result or port. An event would also not let ESP Web Tools wait for asynchronous serial work before Improv takes the reader.

The callback runs once after the port opens at 115200 baud. ESP Web Tools waits for it. The callback must release all stream locks and leave the port open before it returns. If it rejects, ESP Web Tools logs the error and continues the normal post-flash path.

This addresses the callback need in #449.

## Tests

- `npm exec -- prettier --check src`
- `npm exec -- tsc && node --no-warnings --test test/post-flash.test.mjs`
- `npm test`
- `script/build`